### PR TITLE
Update/correct feasible routing calcs

### DIFF
--- a/src/HierarchicalRouting.jl
+++ b/src/HierarchicalRouting.jl
@@ -39,5 +39,8 @@ include("processing/write_files.jl")
 
 export Plot
 
+export load_problem, initial_solution, improve_solution
+
+export process_problem, nearest_neighbour, two_opt, tender_sequential_nearest_neighbour
 
 end

--- a/src/optimization/metric_calcs.jl
+++ b/src/optimization/metric_calcs.jl
@@ -42,7 +42,12 @@ function sortie_cost(
 )::Vector{Float64}
     # TODO: Handling for empty tender tours
     sortie_dist = [dist_matrix[1, tour[1]] for tour in sorties]
-    sortie_dist .+= [length(tour) > 1 ? sum([dist_matrix[tour[i], tour[i+1]] for i in 1:(length(tour)-1)]) : 0 for tour in sorties]
+    sortie_dist .+= [
+        length(tour) > 1 ?
+            sum([dist_matrix[tour[i], tour[i+1]] for i in 1:(length(tour)-1)]) :
+            0
+        for tour in sorties
+    ]
     sortie_dist .+= [dist_matrix[tour[end], 1] for tour in sorties]
     return sortie_dist
 end
@@ -59,16 +64,19 @@ Compute the cost of each sortie in a cluster.
 The cost of each sortie in the cluster.
 """
 function tender_clust_dist(tenders::TenderSolution)::Vector{Float64}
-    sortie_dist = [euclidean(tenders.start, sortie.nodes[1]) for sortie in tenders.sorties] # haversine
+    sortie_dist = [euclidean(tenders.start, sortie.nodes[1]) for sortie in tenders.sorties]
 
     sortie_dist .+= sum([
         length(sortie.nodes) > 1 ?
-        sum(euclidean.(sortie.nodes[1:end-1], sortie.nodes[2:end])) :
-        0.0
+            sum(euclidean.(sortie.nodes[1:end-1], sortie.nodes[2:end])) :
+            0.0
         for sortie in tenders.sorties
     ])
 
-    sortie_dist .+= euclidean.([sortie.nodes[end] for sortie in tenders.sorties], tenders.finish)
+    sortie_dist .+= euclidean.(
+        [sortie.nodes[end] for sortie in tenders.sorties],
+        tenders.finish
+    )
     return sortie_dist
 end
 

--- a/src/optimization/metric_calcs.jl
+++ b/src/optimization/metric_calcs.jl
@@ -42,12 +42,12 @@ function sortie_cost(sorties::Vector{Vector{Int64}}, dist_matrix::Matrix{Float64
 end
 
 """
-    tender_clust_cost(cluster::ClusterSolution)::Vector{Float64}
+    tender_clust_cost(tenders::TenderSolution)::Vector{Float64}
 
 Compute the cost of each sortie in a cluster.
 
 # Arguments
-- `tenters::TenderSolution` : Tender solution.
+- `tenders::TenderSolution` : Tender solution.
 
 # Returns
 - `sortie_dist` : The cost of each sortie in the cluster.

--- a/src/optimization/metric_calcs.jl
+++ b/src/optimization/metric_calcs.jl
@@ -22,7 +22,10 @@ function return_route_distance(route::Vector{Int64}, dist_matrix::Matrix{Float64
 end
 
 """
-    sortie_cost(sortie::Vector{Vector{Int64}}, dist_matrix::Matrix{Float64})
+    sortie_cost(
+        sortie::Vector{Vector{Int64}},
+        dist_matrix::Matrix{Float64}
+    )::Vector{Float64}
 
 Calculate the total distance of all sorties.
 
@@ -33,7 +36,10 @@ Calculate the total distance of all sorties.
 # Returns
 Vector of total distance of each sortie.
 """
-function sortie_cost(sorties::Vector{Vector{Int64}}, dist_matrix::Matrix{Float64})::Vector{Float64}
+function sortie_cost(
+    sorties::Vector{Vector{Int64}},
+    dist_matrix::Matrix{Float64}
+)::Vector{Float64}
     # TODO: Handling for empty tender tours
     sortie_dist = [dist_matrix[1, tour[1]] for tour in sorties]
     sortie_dist .+= [length(tour) > 1 ? sum([dist_matrix[tour[i], tour[i+1]] for i in 1:(length(tour)-1)]) : 0 for tour in sorties]
@@ -42,7 +48,7 @@ function sortie_cost(sorties::Vector{Vector{Int64}}, dist_matrix::Matrix{Float64
 end
 
 """
-    tender_clust_cost(tenders::TenderSolution)::Vector{Float64}
+    tender_clust_dist(tenders::TenderSolution)::Vector{Float64}
 
 Compute the cost of each sortie in a cluster.
 
@@ -50,7 +56,7 @@ Compute the cost of each sortie in a cluster.
 - `tenders::TenderSolution` : Tender solution.
 
 # Returns
-- `sortie_dist` : The cost of each sortie in the cluster.
+The cost of each sortie in the cluster.
 """
 function tender_clust_dist(tenders::TenderSolution)::Vector{Float64}
     sortie_dist = [euclidean(tenders.start, sortie.nodes[1]) for sortie in tenders.sorties] # haversine
@@ -67,30 +73,30 @@ function tender_clust_dist(tenders::TenderSolution)::Vector{Float64}
 end
 
 """
-    mothership_cost_between_clusts(soln::MSTSolution)
+    mothership_dist_between_clusts(route::Route)
 
-Compute the cost of the mothership between clusters, not including across each cluster.
+Compute the cost of the mothership route between clusters, not including across each cluster.
 
 # Arguments
-- `route::Route` : Full mothership route.
+- `route::Route` : Full mothership route between waypoints.
 
 # Returns
-- The sum of (euclidean) mothership distances between clusters.
+The sum of (euclidean) mothership distances between clusters.
 """
 function mothership_dist_between_clusts(route::Route)
     return sum(euclidean(route.nodes[i], route.nodes[i+1]) for i in 1:2:(length(route.nodes)))
 end
 
 """
-    mothership_cost_within_clusts(soln::MSTSolution)
+    mothership_dist_within_clusts(route::Route)
 
 Compute the cost of the mothership within each cluster, not including between clusters.
 
 # Arguments
-- `route::Route` : Full mothership route.
+- `route::Route` : Full mothership route between waypoints.
 
 # Returns
-- The sum of (euclidean) mothership distances across/within each cluster.
+The sum of (euclidean) mothership distances across/within each cluster.
 """
 function mothership_dist_within_clusts(route::Route)
     return [euclidean(route.nodes[i], route.nodes[i+1]) for i in 2:2:(length(route.nodes)-1)]
@@ -111,7 +117,7 @@ This is the longest path for a return trip, quantified as the sum of:
 - `vessel_weightings::NTuple{2, Float64}` : The weightings for mothership and sortie costs.
 
 # Returns
-- The total (critical path) cost of the solution.
+The total (critical path) cost of the solution.
 """
 function critical_path(soln::MSTSolution, vessel_weightings::NTuple{2, Float64}=(1.0, 1.0))
 

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -1,7 +1,7 @@
 
 """
     perturb_swap_solution(
-        soln::MSTSolution,
+        soln::MSTSolution;
         clust_idx::Int=-1,
         exclusions::DataFrame = DataFrame()
     )
@@ -14,10 +14,10 @@ Perturb the solution by swapping two nodes in a cluster.
 - `exclusions` : DataFrame of exclusions. Default = DataFrame().
 
 # Returns
-- Perturbed full solution.
+Perturbed full solution.
 """
 function perturb_swap_solution(
-    soln::MSTSolution,
+    soln::MSTSolution;
     clust_idx::Int=-1,
     exclusions::DataFrame = DataFrame()
 )

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -43,7 +43,7 @@ function perturb_swap_solution(
 
     # Determine node indices to swap
     if sortie_a_idx == sortie_b_idx
-        # Ensure two distinct node indices selected from same sortie
+        # Ensure two distinct node indices are selected from same sortie
         sortie_length = length(sortie_a.nodes)
         if sortie_length < 2
             return soln

--- a/src/plotting/plots.jl
+++ b/src/plotting/plots.jl
@@ -280,7 +280,11 @@ function linestrings!(
     # Plot LineStrings
     for (idx, line_string) in enumerate(line_strings)
         line_color = color[idx]
-        points = [Point(p[1], p[2]) for l in line_string for p in l.points]
+
+        # If line_string is a single LineString, iterate over its points directly.
+        points = hasproperty(line_string, :points) ?
+                 [Point(p[1], p[2]) for p in line_string.points] :
+                 [Point(p[1], p[2]) for l in line_string for p in l.points]
         lines!(ax, points, color = line_color, linewidth = 2)
     end
 

--- a/src/problem/problem_setup.jl
+++ b/src/problem/problem_setup.jl
@@ -86,7 +86,8 @@ function load_problem(target_scenario::String="")
         joinpath(output_dir, "ms_exclusion.gpkg"),
         joinpath(output_dir, "ms_exclusion.tif")
     )
-    ms_exclusions = ms_exclusion_zones_df |> simplify_exclusions! |> buffer_exclusions! |> unionize_overlaps! |> simplify_exclusions! |> unionize_overlaps!
+    ms_exclusions = ms_exclusion_zones_df |> simplify_exclusions! |> buffer_exclusions! |>
+        unionize_overlaps! |> simplify_exclusions! |> unionize_overlaps!
 
     t_exclusions = process_exclusions(
         env_data["bathy"].rast_file,

--- a/src/problem/problem_setup.jl
+++ b/src/problem/problem_setup.jl
@@ -97,15 +97,19 @@ function load_problem(target_scenario::String="")
         joinpath(output_dir, "t_exclusion.gpkg"),
         joinpath(output_dir, "t_exclusion.tif")
     )
-    t_exclusions = unionize_overlaps!(
-        buffer_exclusions!(
-            simplify_exclusions!(
-                t_exclusions,
-                min_area=20,
-                simplify_tol=1
-            ),
-            buffer_dist=0.1
-        )
+    t_exclusions = simplify_exclusions!(
+        unionize_overlaps!(
+            buffer_exclusions!(
+                simplify_exclusions!(
+                    t_exclusions,
+                    min_area=20,
+                    simplify_tol=2
+                ),
+                buffer_dist=0.1
+            )
+        ),
+        min_area=20,
+        simplify_tol=2
     )
 
     mothership = Vessel(exclusion = ms_exclusions, weighting = config["parameters"]["weight_ms"])

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -2,12 +2,9 @@
 """
     initial_solution(problem::Problem)
 
-Generate an initial solution to the problem
-    for mothership
-        using the nearest neighbour heuristic, and then
-        improving the solution using the 2-opt heuristic;
-    for tenders
-        using the sequential nearest neighbour heuristic.
+Generate an initial solution to the problem for mothership using the nearest neighbour
+heuristic, and then improving the solution using the 2-opt heuristic; for tenders using
+the sequential nearest neighbour heuristic.
 
 # Arguments
 - `problem::Problem`: Problem instance to solve

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -18,12 +18,19 @@ function initial_solution(problem::Problem)
     clusters, cluster_centroids_df = process_problem(problem)
 
     # Nearest Neighbour to generate initial mothership route & matrix
-    ms_soln_NN = nearest_neighbour(cluster_centroids_df, problem.mothership.exclusion, problem.tenders.exclusion)
+    ms_soln_NN = nearest_neighbour(
+        cluster_centroids_df, problem.mothership.exclusion, problem.tenders.exclusion
+    )
 
     # 2-opt to improve the NN soln
-    ms_soln_2opt = two_opt(ms_soln_NN, problem.mothership.exclusion, problem.tenders.exclusion)
+    ms_soln_2opt = two_opt(
+        ms_soln_NN, problem.mothership.exclusion, problem.tenders.exclusion
+    )
 
-    clust_seq = [i for i in ms_soln_2opt.cluster_sequence.id if i!==0 && i <= length(clusters)]
+    clust_seq = filter(
+        i -> i != 0 && i <= length(clusters),
+        ms_soln_2opt.cluster_sequence.id
+    )
     tender_soln = HierarchicalRouting.TenderSolution[]
 
     for (i, cluster_id) in enumerate(clust_seq)

--- a/src/processing/processing.jl
+++ b/src/processing/processing.jl
@@ -38,7 +38,7 @@ end
 """
     get_linestrings(graph_matrix::Matrix{
     Tuple{
-        Dict{Int64, Point{2, Float64}},
+        Vector{Point{2, Float64}},
         Vector{SimpleWeightedGraphs.SimpleWeightedEdge{Int64, Float64}}
     }},
     waypoints::Vector{Point{2, Float64}})

--- a/src/processing/processing.jl
+++ b/src/processing/processing.jl
@@ -36,27 +36,36 @@ function target_threshold(targets::Raster, threshold::Float64)
 end
 
 """
-    get_linestrings(graph_matrix::Matrix{
-    Tuple{
-        Vector{Point{2, Float64}},
-        Vector{SimpleWeightedGraphs.SimpleWeightedEdge{Int64, Float64}}
-    }},
-    waypoints::Vector{Point{2, Float64}})
+    get_linestrings(
+        graph_matrix::Matrix{
+            Tuple{
+                Vector{Point{2, Float64}},
+                Vector{SimpleWeightedGraphs.SimpleWeightedEdge{Int64, Float64}}
+            }
+        },
+        waypoints::Vector{Point{2, Float64}}
+    )
 
-Between each sequential pair of waypoints: create a single LineString across all points defining its path.
+Between each sequential pair of waypoints: create a single LineString across all points
+defining its path.
 
 # Arguments
-- `graph_matrix::Matrix{Tuple{Dict{Int64, Point{2, Float64}}, Vector{SimpleWeightedGraphs.SimpleWeightedEdge{Int64, Float64}}}}`: The graph matrix.
+- `graph_matrix::Matrix{
+    Vector{Point{2, Float64}},
+    Vector{SimpleWeightedGraphs.SimpleWeightedEdge{Int64, Float64}}}}`:
+    The graph matrix.
 - `waypoints::Vector{Point{2, Float64}}`: The waypoints.
 
 # Returns
 - A vector of LineStrings.
 """
-function get_linestrings(graph_matrix::Matrix{
-    Tuple{
-        Vector{Point{2, Float64}},
-        Vector{SimpleWeightedGraphs.SimpleWeightedEdge{Int64, Float64}}
-    }},
+function get_linestrings(
+    graph_matrix::Matrix{
+        Tuple{
+            Vector{Point{2, Float64}},
+            Vector{SimpleWeightedGraphs.SimpleWeightedEdge{Int64, Float64}}
+        }
+    },
     waypoints::Vector{Point{2, Float64}}
 )
 

--- a/src/processing/processing.jl
+++ b/src/processing/processing.jl
@@ -54,7 +54,7 @@ Between each sequential pair of waypoints: create a single LineString across all
 """
 function get_linestrings(graph_matrix::Matrix{
     Tuple{
-        Dict{Int64, Point{2, Float64}},
+        Vector{Point{2, Float64}},
         Vector{SimpleWeightedGraphs.SimpleWeightedEdge{Int64, Float64}}
     }},
     waypoints::Vector{Point{2, Float64}}
@@ -68,24 +68,24 @@ function get_linestrings(graph_matrix::Matrix{
 
         # Find the graph entry corresponding to this waypoint pair
         for graph_dict_path in graph_matrix
-            idx_to_point, shortest_path = graph_dict_path
+            point_vector, shortest_path = graph_dict_path
 
             # Check if the path starts and ends at the desired waypoints
             if !isempty(shortest_path) && (
                 (
-                    idx_to_point[shortest_path[1].src] == start_point &&
-                    idx_to_point[shortest_path[end].dst] == end_point
+                    point_vector[shortest_path[1].src] == start_point &&
+                    point_vector[shortest_path[end].dst] == end_point
                 )
                 ||
                 (
-                    idx_to_point[shortest_path[1].src] == end_point &&
-                    idx_to_point[shortest_path[end].dst] == start_point
+                    point_vector[shortest_path[1].src] == end_point &&
+                    point_vector[shortest_path[end].dst] == start_point
                 )
             )
 
                 # Extract points along path
-                path_points = [idx_to_point[e.src] for e in shortest_path]
-                push!(path_points, idx_to_point[shortest_path[end].dst])
+                path_points = [point_vector[e.src] for e in shortest_path]
+                push!(path_points, point_vector[shortest_path[end].dst])
 
                 push!(line_strings, LineString(path_points))
                 break

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -162,8 +162,7 @@ function shortest_feasible_path(
         widest_verts = find_widest_points(
             final_point,
             initial_point,
-            DataFrame(exclusions[initial_exclusion_idx,:]),
-            0
+            DataFrame(exclusions[initial_exclusion_idx,:])
         )[1]
 
         # Continue building network from each of widest vertices to final point
@@ -261,8 +260,7 @@ function build_network!(
     candidates, next_exclusion_idxs = HierarchicalRouting.find_widest_points(
         current_point,
         final_point,
-        exclusions,
-        current_exclusion_idx
+        exclusions
     )
 
     for (vertex, next_exclusion_idx) in zip(candidates, next_exclusion_idxs)

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -206,7 +206,7 @@ function build_network!(
         current_point,
         final_point,
         exclusions,
-        [current_exclusion]
+        current_exclusion
     )
 
     for vertex in candidates

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -218,14 +218,14 @@ function build_network!(
         return
     end
 
-    candidates, next_exclusion_idx = HierarchicalRouting.find_widest_points(
+    candidates, next_exclusion_idxs = HierarchicalRouting.find_widest_points(
         current_point,
         final_point,
         exclusions,
         current_exclusion
     )
 
-    for vertex in candidates
+    for (vertex, next_exclusion_idx) in zip(candidates, next_exclusion_idxs)
 
         # Record new point/edge
         push!(points_from, current_point)

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -22,8 +22,7 @@ function get_feasible_matrix(nodes::Vector{Point{2, Float64}}, exclusions::DataF
             if nodes[i] != nodes[j]
                 # TODO: Process elsewhere
                 # Check if any of the points are within an exclusion zone
-                if point_in_exclusion(nodes[i], exclusions) ||
-                    point_in_exclusion(nodes[j], exclusions)
+                if any(point_in_exclusion.([nodes[i], nodes[j]], [exclusions]))
                     dist_matrix[i, j] = dist_matrix[j, i] = Inf
                 else
                     dist_matrix[i, j], path_matrix[i, j] = HierarchicalRouting.shortest_feasible_path(nodes[i], nodes[j], exclusions)
@@ -36,11 +35,9 @@ function get_feasible_matrix(nodes::Vector{Point{2, Float64}}, exclusions::DataF
     return dist_matrix, path_matrix
 end
 
-function point_in_exclusion(pt::Point{2,Float64}, exclusions::DataFrame)
-        if any(AG.contains.(exclusions.geometry, Ref(AG.createpoint(pt[1], pt[2]))))
-            return true
-        end
-    return false
+function point_in_exclusion(point::Point{2,Float64}, exclusions::DataFrame)
+    point_ag = AG.createpoint(point[1], point[2])
+    return any(AG.contains.(exclusions.geometry, [point_ag]))
 end
 
 """

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -72,9 +72,25 @@ function get_feasible_vector(nodes::Vector{Point{2, Float64}}, exclusions::DataF
     return dist_vector, path_vector
 end
 
+"""
+    point_in_exclusion(point::Point{2, Float64}, exclusions::DataFrame)
+
+Check if a point is within an exclusion zone.
+
+# Arguments
+- `point::Point{2, Float64}`: Point to check.
+- `exclusions::DataFrame`: A DataFrame containing exclusion zone polygons.
+
+# Returns
+- `true` if point is within an exclusion zone, `false` otherwise.
+"""
 function point_in_exclusion(point::Point{2,Float64}, exclusions::DataFrame)
     point_ag = AG.createpoint(point[1], point[2])
     return any(AG.contains.(exclusions.geometry, [point_ag]))
+end
+function point_in_exclusion(point::Point{2,Float64}, exclusion)
+point_ag = AG.createpoint(point[1], point[2])
+return any(AG.contains(exclusion, point_ag))
 end
 
 """

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -15,7 +15,7 @@ Create a matrix of distances of feasible paths between waypoints accounting for 
 function get_feasible_matrix(nodes::Vector{Point{2, Float64}}, exclusions::DataFrame)
     n_points = length(nodes)
     dist_matrix = zeros(Float64, n_points, n_points)
-    path_matrix = fill((Vector{Point{2, Float64}}(), Vector{SimpleWeightedGraphs.SimpleWeightedEdge{Int64, Float64}}()), n_points, n_points)
+    path_matrix = fill(Vector{LineString{2, Float64}}(), n_points, n_points)
 
     for j in 1:n_points
         for i in 1:j-1
@@ -95,7 +95,9 @@ function shortest_feasible_path(initial_point::Point{2, Float64}, final_point::P
     path = a_star(graph, 1, final_point_idx, graph.weights)
     dist = sum(graph.weights[p.src, p.dst] for p in path)
 
-    return dist, (idx_to_point, path)
+    linestring_path = [LineString([idx_to_point[segment.src], idx_to_point[segment.dst]]) for segment in path]
+
+    return dist, linestring_path
 end
 
 """

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -124,13 +124,13 @@ function shortest_feasible_path(initial_point::Point{2, Float64}, final_point::P
 
     points_from = Point{2,Float64}[]
     points_to = Point{2,Float64}[]
-    exclusion_idx = Int[]
+    exclusion_idxs = Int[]
 
     # TODO: check if path from current_point to (left_point, right_point) is feasible (no intersecting polygons in between)
     build_network!(
         points_from,
         points_to,
-        exclusion_idx,
+        exclusion_idxs,
         initial_point,
         final_point,
         exclusions,
@@ -189,7 +189,7 @@ end
     build_network!(
     points_from::Vector{Point{2, Float64}},
     points_to::Vector{Point{2, Float64}},
-    exclusion_idx::Vector{Union{Int,Nothing}},
+    exclusion_idxs::Vector{Int},
     current_point::Point{2, Float64},
     final_point::Point{2, Float64},
     exclusions::DataFrame,
@@ -198,7 +198,7 @@ end
 )
 
 Build a network of points to connect to each other.
-Vectors `points_from`, `points_to`, and `exclusion_idx` are modified in place.
+Vectors `points_from`, `points_to`, and `exclusion_idxs` are modified in place.
 
 # Returns
 - `nothing`
@@ -206,7 +206,7 @@ Vectors `points_from`, `points_to`, and `exclusion_idx` are modified in place.
 function build_network!(
     points_from::Vector{Point{2, Float64}},
     points_to::Vector{Point{2, Float64}},
-    exclusion_idx::Vector{Int},
+    exclusion_idxs::Vector{Int},
     current_point::Point{2, Float64},
     final_point::Point{2, Float64},
     exclusions::DataFrame,
@@ -233,7 +233,7 @@ function build_network!(
         # Record new point/edge
         push!(points_from, current_point)
         push!(points_to, vertex)
-        push!(exclusion_idx, next_exclusion_idx)
+        push!(exclusion_idxs, next_exclusion_idx)
 
         # If verticex already visited/explored, skip
         # If final exclusion zone reached, vertices added to graph later in build_graph()
@@ -246,7 +246,7 @@ function build_network!(
         build_network!(
             points_from,
             points_to,
-            exclusion_idx,
+            exclusion_idxs,
             vertex,
             final_point,
             exclusions,

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -210,10 +210,6 @@ function build_network!(
     )
 
     for vertex in candidates
-        # Skip vertices already visited
-        if vertex ∈ points_from
-            continue
-        end
 
         # Record new point/edge
         push!(points_from, current_point)
@@ -221,6 +217,10 @@ function build_network!(
         push!(exclusion_idx, next_exclusion_idx)
 
         if (next_exclusion_idx == final_exclusion_idx && !isnothing(next_exclusion_idx))
+            continue
+        end
+        # Skip vertices already visited
+        if vertex ∈ points_from #|| isnothing(vertex) || vertex == current_point
             continue
         end
 

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -1,16 +1,21 @@
 
 """
-    get_feasible_matrix(nodes::Vector{Point{2, Float64}}, exclusions::DataFrame)
+    get_feasible_matrix(
+        nodes::Vector{Point{2, Float64}},
+        exclusions::DataFrame
+    )::Tuple{Matrix{Float64}, Matrix{Vector{LineString{2, Float64}}}}
 
-Create a matrix of distances of feasible paths between waypoints accounting for (avoiding) environmental constraints.
+Create matrices of distances and paths for feasible routes between waypoints accounting for
+    (avoiding) environmental constraints.
 
 # Arguments
 - `nodes::Vector{Point{2, Float64}}` : Vector of lat long tuples.
-- `exclusions::DataFrame` : DataFrame containing exclusion zones representing given vehicle's cumulative environmental constraints.
+- `exclusions::DataFrame` :Exclusion zones representing vehicle's environmental constraints.
 
 # Returns
 - `dist_matrix::Matrix{Float64}` : A matrix of distances between waypoints.
-- `path_matrix` : A vector of paths between waypoints, represented as LineStrings.
+- `path_matrix::Matrix{Vector{LineString{2, Float64}}}` : A vector of paths between
+    waypoints.
 """
 function get_feasible_matrix(
     nodes::Vector{Point{2, Float64}},
@@ -78,12 +83,14 @@ end
 
 """
     point_in_exclusion(point::Point{2, Float64}, exclusions::DataFrame)
+    point_in_exclusion(point::Point{2, Float64}, exclusion::AG.IGeometry)
 
 Check if a point is within an exclusion zone.
 
 # Arguments
 - `point::Point{2, Float64}`: Point to check.
 - `exclusions::DataFrame`: A DataFrame containing exclusion zone polygons.
+- `exclusion::AG.IGeometry`: One exclusion zone polygon from exclusions DataFrame.
 
 # Returns
 - `true` if point is within an exclusion zone, `false` otherwise.
@@ -92,7 +99,7 @@ function point_in_exclusion(point::Point{2,Float64}, exclusions::DataFrame)
     point_ag = AG.createpoint(point[1], point[2])
     return any(AG.contains.(exclusions.geometry, [point_ag]))
 end
-function point_in_exclusion(point::Point{2,Float64}, exclusion)
+function point_in_exclusion(point::Point{2,Float64}, exclusion::AG.IGeometry)
 point_ag = AG.createpoint(point[1], point[2])
 return any(AG.contains(exclusion, point_ag))
 end
@@ -102,7 +109,7 @@ end
         initial_point::Point{2, Float64},
         final_point::Point{2, Float64},
         exclusions::DataFrame
-    )
+    )::Tuple{Float64, Vector{LineString{2, Float64}}}
 
 Find the shortest feasible path between two points.
 - Build network of all polygon vertices that recursively intersect with line to finish, from

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -62,7 +62,7 @@ function get_feasible_vector(nodes::Vector{Point{2, Float64}}, exclusions::DataF
                 # TODO: Process elsewhere
                 # Check if any of the points are within an exclusion zone
                 if any(point_in_exclusion.([nodes[i], nodes[i+1]], [exclusions]))
-                    dist_vector[i, i+1] = Inf
+                    dist_vector[i] = Inf
                 else
                     dist_vector[i], path_vector[i] = HierarchicalRouting.shortest_feasible_path(nodes[i], nodes[i+1], exclusions)
                 end

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -10,9 +10,12 @@ Create a matrix of distances of feasible paths between waypoints accounting for 
 
 # Returns
 - `dist_matrix::Matrix{Float64}` : A matrix of distances between waypoints.
-- `path_matrix` : A vector of tuples containing the graph, point to index mapping, and edges for each pair of waypoints.
+- `path_matrix` : A vector of paths between waypoints, represented as LineStrings.
 """
-function get_feasible_matrix(nodes::Vector{Point{2, Float64}}, exclusions::DataFrame)
+function get_feasible_matrix(
+    nodes::Vector{Point{2, Float64}},
+    exclusions::DataFrame
+    )::Tuple{Matrix{Float64}, Matrix{Vector{LineString{2, Float64}}}}
     n_points = length(nodes)
     dist_matrix = zeros(Float64, n_points, n_points)
     path_matrix = fill(Vector{LineString{2, Float64}}(), n_points, n_points)
@@ -46,7 +49,8 @@ between sequential nodes, avoiding exclusions.
 
 # Arguments
 - `nodes::Vector{Point{2, Float64}}` : Vector of lat long tuples.
-- `exclusions::DataFrame` : DataFrame containing exclusion zones representing given vehicle's cumulative environmental constraints.
+- `exclusions::DataFrame` : DataFrame containing exclusion zones representing given
+vehicle's cumulative environmental constraints.
 
 # Returns
 - `dist_vector::Vector{Float64}` : A vector of distances between waypoints.

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -298,26 +298,10 @@ function build_graph(
     final_point::Point{2, Float64}
 )
     is_polygon = !isnothing(final_polygon)
-    poly_vertices = Point{2, Float64}[]
 
-    if is_polygon
-        exterior_ring = AG.getgeom(final_polygon, 0)
-        n_pts = AG.ngeom(exterior_ring)
-
-        vertices = AG.getpoint.([exterior_ring], 0:n_pts-1)
-        points_x, points_y = getindex.(vertices, 1), getindex.(vertices, 2)
-
-        # convex_hull = AG.convexhull(polygon)
-        # # Select points that are either outside or touching the convex hull
-        # points_ag = AG.createpoint.(points_x, points_y)
-        # points_outside_convex_hull = .!AG.contains.([convex_hull], points_ag)
-        # points_touching_convex_hull = AG.touches.([convex_hull], points_ag)
-        # target_points_mask::BitVector = points_outside_convex_hull .|| points_touching_convex_hull
-        # poly_vertices = Point{2, Float64}.(points_x[target_points_mask], points_y[target_points_mask])
-        # n_pts = length(poly_vertices)
-
-        poly_vertices = Point{2, Float64}.(points_x, points_y)
-    end
+    poly_vertices = is_polygon ?
+        collect_polygon_vertices(final_polygon) :
+        Point{2, Float64}[]
 
     # Collect connected points from network
     chain_points = [Point{2,Float64}(p[1], p[2])
@@ -374,4 +358,24 @@ function build_graph(
     end
 
     return graph, unique_points, pt_to_idx[final_point]
+end
+
+function collect_polygon_vertices(polygon::AG.IGeometry)
+    exterior_ring = AG.getgeom(polygon, 0)
+    n_pts = AG.ngeom(exterior_ring)
+
+    vertices = AG.getpoint.([exterior_ring], 0:n_pts-1)
+    points_x, points_y = getindex.(vertices, 1), getindex.(vertices, 2)
+
+    # convex_hull = AG.convexhull(polygon)
+    # # Select points that are either outside or touching the convex hull
+    # points_ag = AG.createpoint.(points_x, points_y)
+    # points_outside_convex_hull = .!AG.contains.([convex_hull], points_ag)
+    # points_touching_convex_hull = AG.touches.([convex_hull], points_ag)
+    # target_points_mask::BitVector = points_outside_convex_hull .|| points_touching_convex_hull
+    # poly_vertices = Point{2, Float64}.(points_x[target_points_mask], points_y[target_points_mask])
+    # n_pts = length(poly_vertices)
+
+    poly_vertices = Point{2, Float64}.(points_x, points_y)
+    return poly_vertices
 end

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -227,16 +227,18 @@ function build_network!(
 
     for (vertex, next_exclusion_idx) in zip(candidates, next_exclusion_idxs)
 
+        if isnothing(vertex) || vertex == current_point
+            continue
+        end
         # Record new point/edge
         push!(points_from, current_point)
         push!(points_to, vertex)
         push!(exclusion_idx, next_exclusion_idx)
 
-        if (next_exclusion_idx == final_exclusion_idx && !isnothing(next_exclusion_idx))
-            continue
-        end
-        # Skip vertices already visited
-        if vertex ∈ points_from #|| isnothing(vertex) || vertex == current_point
+        # If verticex already visited/explored, skip
+        # If final exclusion zone reached, vertices added to graph later in build_graph()
+        if vertex ∈ points_from ||
+            (next_exclusion_idx == final_exclusion_idx && !isnothing(next_exclusion_idx))
             continue
         end
 

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -25,14 +25,8 @@ function get_feasible_matrix(nodes::Vector{Point{2, Float64}}, exclusions::DataF
             if nodes[i] != nodes[j]
                 # TODO: Process elsewhere
                 # Check if any of the points are within an exclusion zone
-                if any(
-                    AG.contains.(
-                        exclusions.geometry, Ref(AG.createpoint(nodes[j][1], nodes[j][2])))
-                ) ||
-                any(
-                    AG.contains.(
-                        exclusions.geometry, Ref(AG.createpoint(nodes[i][1], nodes[i][2])))
-                )
+                if point_in_exclusion(nodes[i], exclusions) ||
+                    point_in_exclusion(nodes[j], exclusions)
                     feasible_matrix[i, j] = feasible_matrix[j, i] = Inf
                 else
                     feasible_matrix[i, j], feasible_path[i,j] = HierarchicalRouting.shortest_feasible_path(nodes[i], nodes[j], exclusions, ignore_exclusions_flag)
@@ -43,6 +37,13 @@ function get_feasible_matrix(nodes::Vector{Point{2, Float64}}, exclusions::DataF
     end
 
     return feasible_matrix, feasible_path
+end
+
+function point_in_exclusion(pt::Point{2,Float64}, exclusions::DataFrame)
+        if any(AG.contains.(exclusions.geometry, Ref(AG.createpoint(pt[1], pt[2]))))
+            return true
+        end
+    return false
 end
 
 """

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -9,14 +9,13 @@ Create a matrix of distances of feasible paths between waypoints accounting for 
 - `exclusions::DataFrame` : DataFrame containing exclusion zones representing given vehicle's cumulative environmental constraints.
 
 # Returns
-- `feasible_matrix::Matrix{Float64}` : A matrix of distances between waypoints.
-- `feasible_path` : A vector of tuples containing the graph, point to index mapping, and edges for each pair of waypoints.
+- `dist_matrix::Matrix{Float64}` : A matrix of distances between waypoints.
+- `path_matrix` : A vector of tuples containing the graph, point to index mapping, and edges for each pair of waypoints.
 """
-function get_feasible_matrix(nodes::Vector{Point{2, Float64}}, exclusions::DataFrame,
-    )
+function get_feasible_matrix(nodes::Vector{Point{2, Float64}}, exclusions::DataFrame)
     n_points = length(nodes)
-    feasible_matrix = zeros(Float64, n_points, n_points)
-    feasible_path = fill((Dict{Int64, Point{2, Float64}}(), Vector{SimpleWeightedGraphs.SimpleWeightedEdge{Int64, Float64}}()), n_points, n_points)
+    dist_matrix = zeros(Float64, n_points, n_points)
+    path_matrix = fill((Dict{Int64, Point{2, Float64}}(), Vector{SimpleWeightedGraphs.SimpleWeightedEdge{Int64, Float64}}()), n_points, n_points)
 
     for j in 1:n_points
         for i in 1:j-1
@@ -25,16 +24,16 @@ function get_feasible_matrix(nodes::Vector{Point{2, Float64}}, exclusions::DataF
                 # Check if any of the points are within an exclusion zone
                 if point_in_exclusion(nodes[i], exclusions) ||
                     point_in_exclusion(nodes[j], exclusions)
-                    feasible_matrix[i, j] = feasible_matrix[j, i] = Inf
+                    dist_matrix[i, j] = dist_matrix[j, i] = Inf
                 else
-                    feasible_matrix[i, j], feasible_path[i, j] = HierarchicalRouting.shortest_feasible_path(nodes[i], nodes[j], exclusions)
-                    feasible_matrix[j, i] = feasible_matrix[i, j]
+                    dist_matrix[i, j], path_matrix[i, j] = HierarchicalRouting.shortest_feasible_path(nodes[i], nodes[j], exclusions)
+                    dist_matrix[j, i] = dist_matrix[i, j]
                 end
             end
         end
     end
 
-    return feasible_matrix, feasible_path
+    return dist_matrix, path_matrix
 end
 
 function point_in_exclusion(pt::Point{2,Float64}, exclusions::DataFrame)

--- a/src/routing/polygon_traversal.jl
+++ b/src/routing/polygon_traversal.jl
@@ -64,8 +64,6 @@ function find_widest_points(
         angle = vector_angle(base_vec, vec)
 
         if is_visible(current_point, pt, exclusions) && pt != current_point
-            # TODO Try to avoid going backwards - i.e. angle > abs(π/2)
-            # ! only the case when point is in the convex hull of the exclusion zone
             if angle > 0 && angle > max_angle_L
                 max_angle_L = angle
                 furthest_vert_L = pt
@@ -81,7 +79,7 @@ function find_widest_points(
 
     for vertex ∈ [furthest_vert_L, furthest_vert_R]
         if !isnothing(vertex)
-            if is_visible(current_point, vertex, exclusions, [current_exclusion_idx])
+            if is_visible(current_point, vertex, exclusions)
                 push!(candidates, vertex)
                 push!(poly_indices, polygon_idx)
             else

--- a/src/routing/polygon_traversal.jl
+++ b/src/routing/polygon_traversal.jl
@@ -58,15 +58,15 @@ function find_widest_points(
         end
         if is_visible(current_point, vertex, exclusions, visited_exclusion_idxs)
             push!(candidates, vertex)
-                push!(poly_indices, polygon_idx)
-            else
+            push!(poly_indices, polygon_idx)
+        else
             new_pts, new_poly_idxs = find_widest_points(
-                    current_point,
-                    vertex,
-                    exclusions,
+                current_point,
+                vertex,
+                exclusions,
                 union(visited_exclusion_idxs, [polygon_idx])
-                )
-                append!(candidates, new_pts)
+            )
+            append!(candidates, new_pts)
             append!(poly_indices, new_poly_idxs)
         end
     end
@@ -101,7 +101,7 @@ end
         final_point::Point{2, Float64},
         exterior_ring,
         n_pts,
-    )::Tuple{Union{Point{2, Float64}, Nothing}, Union{Point{2, Float64}, Nothing}}
+    )::NTuple{2, Union{Point{2, Float64}, Nothing}}
 
 Search for the widest visible vertices on each side of the base vector.
 
@@ -119,7 +119,7 @@ function search_widest_points(
     final_point::Point{2, Float64},
     exterior_ring,
     n_pts,
-)
+)::NTuple{2, Union{Point{2, Float64}, Nothing}}
     max_angle_L, max_angle_R = 0.0, 0.0
     furthest_vert_L, furthest_vert_R = nothing, nothing
 
@@ -157,10 +157,10 @@ end
 
 """
     closest_crossed_polygon(
-    current_point::Point{2, Float64},
-    final_point::Point{2, Float64},
-    exclusions::DataFrame,
-    visited_exclusion_idxs::Vector{Int}
+        current_point::Point{2, Float64},
+        final_point::Point{2, Float64},
+        exclusions::DataFrame,
+        visited_exclusion_idxs::Vector{Int}
     )
 
 Find polygons that intersect with a line segment.
@@ -173,7 +173,7 @@ Find polygons that intersect with a line segment.
 
 # Returns
 - `closest_polygon`: The polygon, LineString and number of vertices of the first/closest
-polygon intersecting with the line segment.
+    polygon intersecting with the line segment.
 - `polygon_idx`: The index of the(first) polygon crossed.
 """
 function closest_crossed_polygon(
@@ -258,10 +258,10 @@ end
 
 """
     is_visible(
-    current_point::Point{2, Float64},
-    final_point::Point{2, Float64},
-    exclusion_poly
-)::Bool
+        current_point::Point{2, Float64},
+        final_point::Point{2, Float64},
+        exclusion_poly
+    )::Bool
 
 Check if a point is visible from another point, given a single exclusion polygon.
     i.e. no exclusion zone intersects the straight line between them.

--- a/src/routing/polygon_traversal.jl
+++ b/src/routing/polygon_traversal.jl
@@ -26,7 +26,7 @@ function find_widest_points(
     current_point::Point{2, Float64},
     final_point::Point{2, Float64},
     exclusions::DataFrame,
-    current_exclusion_idx::Int
+    current_exclusion_idx::Int = 0
 )::Tuple{Vector{Point{2, Float64}}, Vector{Int}}
 
     if is_visible(current_point, final_point, exclusions)

--- a/src/routing/polygon_traversal.jl
+++ b/src/routing/polygon_traversal.jl
@@ -33,8 +33,9 @@ function find_widest_points(
         return [final_point], [0]
     end
     # Find the first/next polygon that the line (current_point, final_point) crosses.
-    (polygon, exterior_ring, n_pts), polygon_idx = HierarchicalRouting.
-        closest_crossed_polygon(current_point, final_point, exclusions, 0)
+    (polygon, exterior_ring, n_pts), polygon_idx = closest_crossed_polygon(
+        current_point, final_point, exclusions, 0
+    )
 
     if isnothing(polygon)
         return [final_point], [0]
@@ -60,10 +61,9 @@ function find_widest_points(
         ]
 
         # Signed angle between base vector and vector to vertex
-        angle = HierarchicalRouting.vector_angle(base_vec, vec)
+        angle = vector_angle(base_vec, vec)
 
-        if HierarchicalRouting.is_visible(current_point, pt, exclusions) &&
-            pt != current_point
+        if is_visible(current_point, pt, exclusions) && pt != current_point
             # TODO Try to avoid going backwards - i.e. angle > abs(π/2)
             # ! only the case when point is in the convex hull of the exclusion zone
             if angle > 0 && angle > max_angle_L

--- a/src/routing/polygon_traversal.jl
+++ b/src/routing/polygon_traversal.jl
@@ -172,7 +172,8 @@ Find polygons that intersect with a line segment.
 - `visited_exclusion_idxs::Vector{Int}`: Indices of exclusion zones already crossed.
 
 # Returns
-- `closest_polygon`: The polygon, LineString and number of vertices of the first/closest polygon intersecting with the line segment.
+- `closest_polygon`: The polygon, LineString and number of vertices of the first/closest
+polygon intersecting with the line segment.
 - `polygon_idx`: The index of the(first) polygon crossed.
 """
 function closest_crossed_polygon(
@@ -185,11 +186,16 @@ function closest_crossed_polygon(
     min_dist = Inf
     polygon_idx = nothing
 
-    line = AG.createlinestring([current_point[1], final_point[1]], [current_point[2], final_point[2]])
+    line = AG.createlinestring(
+        [current_point[1], final_point[1]],
+        [current_point[2], final_point[2]]
+    )
 
     # Define bounding box for line to exclude polygons that do not intersect
-    line_min_x, line_max_x = min(current_point[1], final_point[1]), max(current_point[1], final_point[1])
-    line_min_y, line_max_y = min(current_point[2], final_point[2]), max(current_point[2], final_point[2])
+    line_min_x, line_max_x = min(current_point[1], final_point[1]),
+        max(current_point[1], final_point[1])
+    line_min_y, line_max_y = min(current_point[2], final_point[2]),
+        max(current_point[2], final_point[2])
 
     for (i, row) ∈ enumerate(eachrow(exclusions))
         if i in visited_exclusion_idxs
@@ -280,7 +286,8 @@ function is_visible(
     ])
 
     # TODO: CHECK if commented statement below is necessary/correct/overkill
-    return !AG.intersects(exclusion_poly, line_to_point) || AG.touches(exclusion_poly, line_to_point)
+    return !AG.intersects(exclusion_poly, line_to_point) ||
+        AG.touches(exclusion_poly, line_to_point)
 end
 
 """

--- a/src/routing/polygon_traversal.jl
+++ b/src/routing/polygon_traversal.jl
@@ -227,8 +227,12 @@ function closest_crossed_polygon(
                 AG.touches(AG.createpoint(final_point[1], final_point[2]), geom)
             )
 
+            intersections = AG.intersection(line, geom)
+
+            pts = [AG.getgeom(intersections, i) for i in 0:AG.ngeom(intersections) - 1]
+
             # Find distance to polygon
-            dist = GO.distance(current_point, geom)
+            dist = minimum(GO.distance.([current_point], pts))
 
             # If closer than current closest polygon, update closest polygon
             if dist < min_dist

--- a/src/routing/polygon_traversal.jl
+++ b/src/routing/polygon_traversal.jl
@@ -3,7 +3,8 @@
     find_widest_points(
     current_point::Point{2, Float64},
     final_point::Point{2, Float64},
-    exclusions::DataFrame
+    exclusions::DataFrame,
+    current_exclusion_idx::Int
     )
 
 Find the vertices on each (left/right) side of the line that have the widest angle.
@@ -12,7 +13,7 @@ Find the vertices on each (left/right) side of the line that have the widest ang
 - `current_point::Point{2, Float64}`: The current point marking start of line.
 - `final_point::Point{2, Float64}`: The final point marking end of line.
 - `exclusions::DataFrame`: The dataframe containing the polygon exclusions.
-- `current_exclusions_idx::Vector{Int}`: The indices of the exclusion zones that have already been crossed.
+- `current_exclusion_idx::Int`: The index of the current exclusion zone - to ignore.
 
 # Returns
 - `[furthest_vert_L, furthest_vert_R]`: The vertices with the widest left and right angular deviations from the line.
@@ -22,13 +23,13 @@ function find_widest_points(
     current_point::Point{2, Float64},
     final_point::Point{2, Float64},
     exclusions::DataFrame,
-    current_exclusions_idx::Vector{Int}
+    current_exclusion_idx::Int
 )
     max_angle_L, max_angle_R = 0.0, 0.0
     furthest_vert_L, furthest_vert_R = nothing, nothing
 
     # Find the first/next polygon that the line (current_point, final_point) crosses.
-    (polygon, exterior_ring, n_pts), polygon_idx = HierarchicalRouting.closest_crossed_polygon(current_point, final_point, exclusions, current_exclusions_idx)
+    (polygon, exterior_ring, n_pts), polygon_idx = HierarchicalRouting.closest_crossed_polygon(current_point, final_point, exclusions, current_exclusion_idx)
 
     if isnothing(polygon)
         return [final_point], 0
@@ -81,7 +82,8 @@ end
     closest_crossed_polygon(
     current_point::Point{2, Float64},
     final_point::Point{2, Float64},
-    exclusions::DataFrame
+    exclusions::DataFrame,
+    current_exclusionn_idx::Int
     )
 
 Find polygons that intersect with a line segment.
@@ -90,6 +92,7 @@ Find polygons that intersect with a line segment.
 - `current_point::Point{2, Float64}`: The current point marking start of line.
 - `final_point::Point{2, Float64}`: The final point marking end of line.
 - `exclusions::DataFrame`: The dataframe containing the polygon exclusions.
+- `current_exclusion_idx::Int`: The index of the current exclusion zone - to ignore.
 
 # Returns
 - `closest_polygon`: The polygon, LineString and number of vertices of the first/closest polygon intersecting with the line segment.
@@ -99,7 +102,7 @@ function closest_crossed_polygon(
     current_point::Point{2, Float64},
     final_point::Point{2, Float64},
     exclusions::DataFrame,
-    current_exclusions_idx::Vector{Int}
+    current_exclusion_idx::Int
 )
     closest_polygon = (nothing, nothing, 0)
     min_dist = Inf
@@ -112,7 +115,7 @@ function closest_crossed_polygon(
     line_min_y, line_max_y = min(current_point[2], final_point[2]), max(current_point[2], final_point[2])
 
     for (i, row) in enumerate(eachrow(exclusions))
-        if i in current_exclusions_idx
+        if i == current_exclusion_idx
             continue
         end
 

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -65,8 +65,8 @@ function adjust_waypoint(
     waypoint_geom = AG.createpoint(waypoint[1], waypoint[2])
 
     containing_polygons = [
-        polygon for polygon in exclusions.geometry
-            if AG.contains(polygon, waypoint_geom)
+        AG.convexhull(polygon) for polygon in exclusions.geometry
+            if AG.contains(AG.convexhull(polygon), waypoint_geom)
     ]
 
     if isempty(containing_polygons)

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -189,8 +189,8 @@ function nearest_neighbour(
     # TODO: Use vector rather than DataFrame for cluster_centroids
     # adjust_waypoints to ensure not within exclusion zones - allows for feasible path calc
     feasible_centroids = HierarchicalRouting.adjust_waypoint.(
-        [Point{2, Float64}(row.lon, row.lat) for row in eachrow(cluster_centroids)],
-        Ref(exclusions_mothership)
+        Point{2,Float64}.(cluster_centroids.lon, cluster_centroids.lat),
+        [exclusions_mothership]
     )
 
     cluster_centroids[!, :lon] = [pt[1] for pt in feasible_centroids]

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -206,11 +206,9 @@ function nearest_neighbour(
         current_location = nearest_idx
     end
 
-    # Return to the depot
+    # Return to the depot and adjust cluster_sequence to zero-based indexing
     push!(tour, 1)
     total_distance += dist_matrix[current_location, 1]
-
-    # Adjust cluster_sequence to zero-based indexing
     cluster_sequence = tour .- 1
 
     ordered_centroids = cluster_centroids[[findfirst(==(id), cluster_centroids.id) for id in cluster_sequence], :]
@@ -219,9 +217,9 @@ function nearest_neighbour(
     exclusions_all = vcat(exclusions_mothership, exclusions_tender)
     waypoints = get_waypoints(ordered_centroids, exclusions_all)
 
-    waypoint_feasible_path = get_feasible_matrix(waypoints.waypoint, exclusions_mothership)[2]
-    paths = [waypoint_feasible_path[s, s+1] for s in 1:size(waypoint_feasible_path)[1]-1]
-    path = vcat(paths...)
+    # Calc feasible path between waypoints.
+    waypoint_dist_vector, waypoint_path_vector = get_feasible_vector(waypoints.waypoint, exclusions_mothership)
+    path = vcat(waypoint_path_vector...)
 
     return MothershipSolution(
         cluster_sequence=ordered_centroids,
@@ -297,9 +295,12 @@ function two_opt(
     exclusions_all = vcat(exclusions_mothership, exclusions_tender)
     waypoints = get_waypoints(ordered_nodes, exclusions_all)
 
-    waypoint_feasible_path = get_feasible_matrix(waypoints.waypoint, exclusions_mothership)[2]
-    paths = [waypoint_feasible_path[s, s+1] for s in 1:size(waypoint_feasible_path)[1]-1]
-    path = vcat(paths...)
+    waypoint_dist_vector, waypoint_path_vector = get_feasible_vector(
+        waypoints.waypoint,
+        exclusions_mothership
+    )
+
+    path = vcat(waypoint_path_vector...)
 
     return MothershipSolution(
         cluster_sequence=ordered_nodes,

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -375,19 +375,14 @@ function tender_sequential_nearest_neighbour(
 )
     nodes = [waypoints[1]]
     append!(nodes, cluster.nodes)
-    append!(nodes, [waypoints[2]])
 
     dist_matrix = get_feasible_matrix(nodes, exclusions)[1]
 
     tender_tours = [Int[] for _ in 1:n_tenders]
     visited = falses(length(nodes))
-    visited[1] = visited[end] = true
+    visited[1] = true
 
-    for s in 1:length(cluster.nodes)
-        if dist_matrix[1, s+1] == Inf
-            visited[s+1] = true
-        end
-    end
+    visited[2:end] .= isinf.(dist_matrix[1, 2:end])
 
     # for each tender in number of tenders, sequentially assign closest nodes tender-by-tender stop-by-stop
     for _ in 1:t_cap

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -246,7 +246,6 @@ end
 """
     two_opt(
         ms_soln_current::MothershipSolution,
-        dist_matrix::Matrix{Float64},
         exclusions_mothership::DataFrame,
         exclusions_tender::DataFrame,
     )
@@ -255,7 +254,6 @@ Apply the 2-opt heuristic to improve the current MothershipSolution route (by un
 
 # Arguments
 - `ms_soln_current` : Current MothershipSolution - from nearest_neighbour.
-- `dist_matrix` : Distance matrix between waypoints. Depot is the first, but not last point.
 - `exclusions_mothership` : DataFrame containing exclusion zones for mothership.
 - `exclusions_tender` : DataFrame containing exclusion zones for tenders.
 

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -177,6 +177,10 @@ function nearest_neighbour(
         Ref(exclusions_mothership)
     )
 
+    cluster_centroids[!, :lon] = [pt[1] for pt in feasible_centroids]
+    cluster_centroids[!, :lat] = [pt[2] for pt in feasible_centroids]
+
+    # Create distance matrix between feasible nodes - cluster centroids
     dist_matrix = get_feasible_matrix(
         feasible_centroids,
         exclusions_mothership

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -258,17 +258,17 @@ function two_opt(
     exclusions_tender::DataFrame,
 )
 
-    nodes = ms_soln_current.cluster_sequence
+    cluster_centroids = ms_soln_current.cluster_sequence
     dist_matrix = ms_soln_current.route.dist_matrix
 
     # If depot is last row, remove
-    if nodes.id[1] == nodes.id[end]
-        nodes = nodes[1:end-1, :]
+    if cluster_centroids.id[1] == cluster_centroids.id[end]
+        cluster_centroids = cluster_centroids[1:end-1, :]
     end
 
     # Initialize route as ordered waypoints
-    best_route = [row.id+1 for row in eachrow(nodes)]
-    best_distance = return_route_distance(best_route, ms_soln_current.route.dist_matrix)
+    best_route = [row.id+1 for row in eachrow(cluster_centroids)] # cluster_centroids = cluster_centroids[1:end-1, :]
+    best_distance = return_route_distance(best_route, dist_matrix)
     improved = true
 
     while improved
@@ -287,14 +287,12 @@ function two_opt(
         end
     end
 
-    # Re-orient route to start from the depot (1), and add the depot as final point
+    # Re-orient route to start from and end at the depot, and adjust to zero-based indexing
     best_route = orient_route(best_route)
     push!(best_route, best_route[1])
-
-    # Adjust sequence to zero-based indexing where depot = 0
     best_route .-= 1
 
-    ordered_nodes = nodes[[findfirst(==(id), nodes.id) for id in best_route], :]
+    ordered_nodes = cluster_centroids[[findfirst(==(id), cluster_centroids.id) for id in best_route], :]
     exclusions_all = vcat(exclusions_mothership, exclusions_tender)
     waypoints = get_waypoints(ordered_nodes, exclusions_all)
 

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -220,11 +220,12 @@ function nearest_neighbour(
     waypoints = get_waypoints(ordered_centroids, exclusions_all)
 
     waypoint_feasible_path = get_feasible_matrix(waypoints.waypoint, exclusions_mothership)[2]
-    paths = get_linestrings(waypoint_feasible_path, waypoints.waypoint)
+    paths = [waypoint_feasible_path[s, s+1] for s in 1:size(waypoint_feasible_path)[1]-1]
+    path = vcat(paths...)
 
     return MothershipSolution(
         cluster_sequence=ordered_centroids,
-        route=Route(waypoints.waypoint, dist_matrix, paths)
+        route=Route(waypoints.waypoint, dist_matrix, path)
     )
 end
 
@@ -297,11 +298,12 @@ function two_opt(
     waypoints = get_waypoints(ordered_nodes, exclusions_all)
 
     waypoint_feasible_path = get_feasible_matrix(waypoints.waypoint, exclusions_mothership)[2]
-    paths = get_linestrings(waypoint_feasible_path, waypoints.waypoint)
+    paths = [waypoint_feasible_path[s, s+1] for s in 1:size(waypoint_feasible_path)[1]-1]
+    path = vcat(paths...)
 
     return MothershipSolution(
         cluster_sequence=ordered_nodes,
-        route=Route(waypoints.waypoint, dist_matrix, paths)
+        route=Route(waypoints.waypoint, dist_matrix, path)
     )
 end
 
@@ -417,8 +419,7 @@ function tender_sequential_nearest_neighbour(
     sortie_dist_matrices = [res[1] for res in sortie_mats_paths]
     feasible_paths = [res[2] for res in sortie_mats_paths]
 
-    # TODO: Consider re-reversing reversed paths to pass to get_linestrings
-    paths = [get_linestrings(feasible_paths[s], sorties[s]) for s in 1:length(feasible_paths)]
+    paths = [[feasible_path[s, s+1] for s in 1:size(feasible_path)[1]-1] for feasible_path in feasible_paths]
 
     return TenderSolution(
         cluster.id,
@@ -426,7 +427,7 @@ function tender_sequential_nearest_neighbour(
         waypoints[2],
         [
             Route(
-                sortie, sortie_dist_matrices[i], paths[i]
+                sortie, sortie_dist_matrices[i], vcat(paths[i]...)
             ) for (i, sortie) in enumerate(sorties)
         ],
         dist_matrix

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -43,9 +43,9 @@ function create_exclusion_zones(env_constraint::Raster, threshold::Float64)
 end
 
 """
-adjust_waypoint(
-    waypoint::Point{2, Float64},
-    exclusions::DataFrame,
+    adjust_waypoint(
+        waypoint::Point{2, Float64},
+        exclusions::DataFrame,
     )::Point{2, Float64}
 
 Adjust waypoint if inside exclusion zone to closest boundary point outside exclusion zone.
@@ -164,7 +164,7 @@ end
         nodes::DataFrame,
         exclusions_mothership::DataFrame,
         exclusions_tender::DataFrame,
-        )
+    )
 
 Apply the nearest neighbor algorithm starting from the depot (1st row/col) and returning to the depot.
 
@@ -186,7 +186,7 @@ function nearest_neighbour(
     exclusions_mothership::DataFrame,
     exclusions_tender::DataFrame,
 )
-# TODO: Use vector rather than DataFrame for cluster_centroids
+    # TODO: Use vector rather than DataFrame for cluster_centroids
     # adjust_waypoints to ensure not within exclusion zones - allows for feasible path calc
     feasible_centroids = HierarchicalRouting.adjust_waypoint.(
         [Point{2, Float64}(row.lon, row.lat) for row in eachrow(cluster_centroids)],
@@ -249,7 +249,7 @@ end
         dist_matrix::Matrix{Float64},
         exclusions_mothership::DataFrame,
         exclusions_tender::DataFrame,
-        )
+    )
 
 Apply the 2-opt heuristic to improve the current MothershipSolution route (by uncrossing crossed links) between waypoints.
 


### PR DESCRIPTION
- `nearest_neighbour()` ensure cluster centroids are feasible points to enable fesaible distances
- Waypoints outside convex hulls of exclusions
- Re-write `build_graph()` 
- `build_network!()` to replace `process_point()`
- Recursive `adjust_waypoint()` if `point_in_exclusion()`
- `find_widest_points()` returns vector of points/idxs (not pair) based on recursive function calls
- Call `simplify_exclusions!()` again for tenders to reduce complexity of polygons, and comp time
- Update routing for (start and end) points in convex hulls
- Update `closest_crossed_polygon()` to ensure calcs dist to closest **intersection**
- `tender_sequential_nearest_neighbour()` updated logic and optimized logic to reduce function calls to `get_feasible_matrix()`
- `perturb_swap_solution()` optimization

Function out:
- `point_in_exclusion()` w multiple dispatch
- `vector_angle()`
- `get_feasible_vector()`
- `collect_polygon_vertices()`
- `search_widest_points()`