### PR TITLE
Optimize random sortie selection in perturb_swap_solution()

### DIFF
--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -73,7 +73,7 @@ function perturb_swap_solution(
 
     # TODO:Re-run two-opt on the modified sorties
     # Recompute the feasible paths for the modified sorties
-    updated_tender_tours = [
+    updated_tender_tours::Vector{Vector{Point{2, Float64}}} = [
         [[tender.start]; sortie.nodes; [tender.finish]]
         for sortie in [sortie_a, sortie_b]
     ]
@@ -90,7 +90,7 @@ function perturb_swap_solution(
         vcat(get_feasible_vector(updated_tender_tours[2], exclusions)[2]...)
     )
 
-    tenders_all = [
+    tenders_all::Vector{TenderSolution} = [
         i == clust_idx ?
         tender :
         soln.tenders[i]

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -51,10 +51,7 @@ function perturb_swap_solution(
         elseif sortie_length == 2
             node_a_idx, node_b_idx = 1, 2
         else
-            node_a_idx, node_b_idx = rand(1:sortie_length, 2)
-            while node_a_idx == node_b_idx
-                node_b_idx = rand(1:sortie_length)
-            end
+            node_a_idx, node_b_idx = shuffle(1:sortie_length)[1:2]
         end
     else
         # Chose two random node indices from different sorties

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -78,16 +78,22 @@ function perturb_swap_solution(
         for sortie in [sortie_a, sortie_b]
     ]
 
-    # Update linestrings for the modified sorties
+    # Get new linestrings
+    linestrings::Vector{Vector{Vector{LineString{2, Float64}}}} = getindex.(
+        get_feasible_vector.(updated_tender_tours, Ref(exclusions)),
+        2
+    )
+
+    # Update the modified sorties
     sorties[sortie_a_idx] = Route(
         sortie_a.nodes,
         sortie_a.dist_matrix,
-        vcat(get_feasible_vector(updated_tender_tours[1], exclusions)[2]...)
+        vcat(linestrings[1]...)
     )
     sorties[sortie_b_idx] = Route(
         sortie_b.nodes,
         sortie_b.dist_matrix,
-        vcat(get_feasible_vector(updated_tender_tours[2], exclusions)[2]...)
+        vcat(linestrings[2]...)
     )
 
     tenders_all::Vector{TenderSolution} = [

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -3,7 +3,8 @@
     perturb_swap_solution(
         soln::MSTSolution,
         clust_idx::Int64=-1,
-        exclusions::DataFrame = DataFrame()
+        exclusions::DataFrame = DataFrame();
+        enforce_diff_sortie::Bool = false
     )::MSTSolution
 
 Perturb the solution by swapping two nodes in a cluster.
@@ -12,6 +13,7 @@ Perturb the solution by swapping two nodes in a cluster.
 - `soln`: Solution to perturb.
 - `clust_idx`: Index of the cluster to perturb. Default = -1 randomly selects a cluster.
 - `exclusions`: DataFrame of exclusions. Default = DataFrame().
+- `enforce_diff_sortie`: Boolean flag to enforce different sorties for node swaps.
 
 # Returns
 Perturbed full solution.
@@ -19,7 +21,8 @@ Perturbed full solution.
 function perturb_swap_solution(
     soln::MSTSolution,
     clust_idx::Int64=-1,
-    exclusions::DataFrame = DataFrame()
+    exclusions::DataFrame = DataFrame();
+    enforce_diff_sortie::Bool = false
 )::MSTSolution
     # Choose a random cluster (assume fixed clustering) if none provided
     clust_idx = clust_idx == -1 ? rand(1:length(soln.tenders)) : clust_idx
@@ -33,8 +36,12 @@ function perturb_swap_solution(
         return soln
     end
 
-    # Choose two random sorties from the cluster, ALLOWING for same sortie selection
-    sortie_a_idx, sortie_b_idx = rand(1:length(sorties), 2)
+    # Choose two random sorties to swap nodes between
+    # if enforce_diff_sortie is true: ensure different sorties are selected
+    sortie_a_idx, sortie_b_idx = enforce_diff_sortie ?
+        shuffle(1:length(sorties))[1:2] :
+        rand(1:length(sorties), 2)
+
     sortie_a, sortie_b = sorties[sortie_a_idx], sorties[sortie_b_idx]
 
     # No perturbation possible if a sortie has no nodes

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -4,13 +4,13 @@
         soln::MSTSolution,
         clust_idx::Int64=-1,
         exclusions::DataFrame = DataFrame()
-    )
+    )::MSTSolution
 
 Perturb the solution by swapping two nodes in a cluster.
 
 # Arguments
 - `soln`: Solution to perturb.
-- `clust_idx`: Index of the cluster to perturb. Default = -1.
+- `clust_idx`: Index of the cluster to perturb. Default = -1 randomly selects a cluster.
 - `exclusions`: DataFrame of exclusions. Default = DataFrame().
 
 # Returns
@@ -20,7 +20,7 @@ function perturb_swap_solution(
     soln::MSTSolution,
     clust_idx::Int64=-1,
     exclusions::DataFrame = DataFrame()
-)
+)::MSTSolution
     # Choose a random cluster (assume fixed clustering) if none provided
     clust_idx = clust_idx == -1 ? rand(1:length(soln.tenders)) : clust_idx
 


### PR DESCRIPTION
- Implement `Random.shuffle` to avoid while loops to resample `rand`
- Introduce `enforce_diff_sortie` arg as a flag to enforce selecting different sorties
- Clean up function: use aliases, typing, comment
- Update docstring

Closes #9 