### PR TITLE
Implement 3d clustering

### DIFF
--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -15,9 +15,7 @@ end
         raster::Raster{Int, 2}, k::Int8; tol::Float64=1.0
     )::Raster{Int64, 2}
     apply_kmeans_clustering(
-        raster::Raster{Float64, 2},
-        k::Int8;
-        tol::Float64=1.0,
+        raster::Raster{Float64, 2}, k::Int8; tol::Float64=1.0
     )::Raster{Int64, 2}
 
 Cluster targets sites by applying k-means to target (non-zero) cells in a raster.
@@ -55,9 +53,7 @@ function apply_kmeans_clustering(
     return clustered_targets
 end
 function apply_kmeans_clustering(
-    raster::Raster{Float64, 2},
-    k::Int8;
-    tol::Float64=1.0,
+    raster::Raster{Float64, 2}, k::Int8; tol::Float64=1.0
 )::Raster{Int64, 2}
     indices::Vector{CartesianIndex{2}} = findall(!=(raster.missingval), raster)
     n::Int = length(indices)

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -128,7 +128,7 @@ function calculate_cluster_centroids(
 )::Vector{Cluster}
     unique_clusters = Vector{Int64}(undef, 0)
 
-    if cluster_ids == []
+    if isempty(cluster_ids)
         unique_clusters = clusters_raster[clusters_raster .!= clusters_raster.missingval]
         unique_clusters = sort(unique(unique_clusters))
     else

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -13,7 +13,7 @@ end
 """
     apply_kmeans_clustering(
         raster::Raster{Float64, 2}, k::Int8; tol::Float64=1.0
-    )::Raster{Int, 2}
+    )::Raster{Int64, 2}
 
 Cluster targets sites by applying k-means to target (non-zero) cells in a raster.
 
@@ -40,7 +40,7 @@ function apply_kmeans_clustering(
     coordinates_array[1, :] .= raster.dims[1][rows]
     coordinates_array[2, :] .= raster.dims[2][cols]
 
-    clustering = kmeans(coordinates_array, k; distance=Haversine(), tol=tol, rng=Random.seed!(1))
+    clustering = kmeans(coordinates_array, k; tol=tol, rng=Random.seed!(1))
 
     clustered_targets::Raster{Int64, 2} = similar(raster, Int64)
     clustered_targets[indices] .= clustering.assignments

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -13,7 +13,7 @@ end
 """
     apply_kmeans_clustering(
         raster::Raster{Float64, 2}, k::Int8; tol::Float64=1.0
-    )::Raster{Int64, 2}
+    )::Raster{Int, 2}
 
 Cluster targets sites by applying k-means to target (non-zero) cells in a raster.
 
@@ -26,7 +26,7 @@ Cluster targets sites by applying k-means to target (non-zero) cells in a raster
 A new raster containing the cluster IDs.
 """
 function apply_kmeans_clustering(
-    raster::Raster{Float64, 2}, k::Int8; tol::Float64=1.0
+    raster::Raster{Int, 2}, k::Int8; tol::Float64=1.0
 )::Raster{Int64, 2}
     indices::Vector{CartesianIndex{2}} = findall(x -> x != raster.missingval, raster)
     n::Int = length(indices)
@@ -171,7 +171,7 @@ function process_targets(
 )::Raster{Int64}
     if endswith(targets.path, ".geojson")
         suitable_targets_all = process_geometry_targets(
-            targets,
+            targets.gdf.geometry,
             EPSG_code
         )
     else

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -12,10 +12,17 @@ end
 
 """
     apply_kmeans_clustering(
-        raster::Raster{Float64, 2}, k::Int8; tol::Float64=1.0
+        raster::Raster{Int, 2}, k::Int8; tol::Float64=1.0
+    )::Raster{Int64, 2}
+    apply_kmeans_clustering(
+        raster::Raster{Float64, 2},
+        k::Int8;
+        tol::Float64=1.0,
     )::Raster{Int64, 2}
 
 Cluster targets sites by applying k-means to target (non-zero) cells in a raster.
+- Float64 raster is assumed to contain disturbance values, addressed buy 3d clustering
+- Int raster is assumed to contain cluster ID values, addressed by 2d spatial clustering.
 
 # Arguments
 - `raster`: Raster containing the target geometries.
@@ -43,6 +50,64 @@ function apply_kmeans_clustering(
     clustering = kmeans(coordinates_array, k; tol=tol, rng=Random.seed!(1))
 
     clustered_targets::Raster{Int64, 2} = similar(raster, Int64)
+    clustered_targets[indices] .= clustering.assignments
+
+    return clustered_targets
+end
+function apply_kmeans_clustering(
+    raster::Raster{Float64, 2},
+    k::Int8;
+    tol::Float64=1.0,
+)::Raster{Int64, 2}
+    indices::Vector{CartesianIndex{2}} = findall(!=(raster.missingval), raster)
+    n::Int = length(indices)
+
+    # 2D coordinate matrix for clustering
+    coordinates_array_3d = Matrix{Float64}(undef, 3, n)
+    coordinates_array_3d[1, :] .= raster.dims[1][getindex.(indices, 1)]
+    coordinates_array_3d[2, :] .= raster.dims[2][getindex.(indices, 2)]
+    coordinates_array_3d[3, :] .= [raster[i] for i in indices]
+
+    # Create k_d (random number between k:k^2) clusters to create disturbance on subset
+    k_d = rand(k:k^2)
+    lambda = 1E4        #! magic number
+
+    disturbance_clusters = kmeans(
+        coordinates_array_3d,
+        k_d;
+        tol=tol,
+        rng=Random.seed!(1)
+    )
+
+    # Create a score based on the disturbance values for each cluster
+    disturbance_scores = Vector{Float64}(undef, length(indices))
+    # Calculate the mean disturbance value for each cluster
+    cluster_means = [
+        mean(coordinates_array_3d[3, disturbance_clusters.assignments .== i])
+        for i in 1:k_d
+    ]
+    # Assign the disturbance value to every node in the cluster
+    disturbance_scores .= cluster_means[disturbance_clusters.assignments]
+
+    # create a threshold to remove nodes with a score above the threshold
+    #? change distribution to make threshold more likely to be higher
+    disturbance_magnitude = minimum(disturbance_scores) +
+        rand()*(maximum(disturbance_scores) - minimum(disturbance_scores))
+
+    # Remove nodes with a score above the threshold
+    surviving_mask = disturbance_scores .<= disturbance_magnitude
+    coordinates_array_2d_disturbed = coordinates_array_3d[1:2, surviving_mask]
+    indices = indices[surviving_mask]
+
+    #re-cluster the remaining nodes into k clusters
+    clustering = kmeans(
+        coordinates_array_2d_disturbed,
+        k;
+        tol=tol,
+        rng=Random.seed!(1)
+    )
+
+    clustered_targets = similar(raster, Int64, missingval=0)
     clustered_targets[indices] .= clustering.assignments
 
     return clustered_targets
@@ -182,7 +247,7 @@ function process_targets(
         )
     end
 
-    suitable_targets_subset::Raster = Rasters.crop(suitable_targets_all, to=subset.geom)
+    suitable_targets_subset::Raster{Int} = Rasters.crop(suitable_targets_all, to=subset.geom)
     if !isfile(target_subset_path)
         write(target_subset_path, suitable_targets_subset; force=true)
     end

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -66,8 +66,6 @@ function apply_kmeans_clustering(
 
     # Create k_d (random number between k:k^2) clusters to create disturbance on subset
     k_d = rand(k:k^2)
-    lambda = 1E4        #! magic number
-
     disturbance_clusters = kmeans(
         coordinates_array_3d,
         k_d;

--- a/src/problem/problem_setup.jl
+++ b/src/problem/problem_setup.jl
@@ -114,7 +114,7 @@ function load_problem(target_path::String)::Problem
         wave_disturbance, subset_bbox
     )
     suitable_targets_subset = process_geometry_targets(
-        target_gdf_subset.geometry, disturbance_data_subset, EPSG_code
+        target_gdf_subset.geometry, EPSG_code
     )
     indices::Vector{CartesianIndex{2}} = findall(
         x -> x != suitable_targets_subset.missingval,

--- a/src/processing/reads.jl
+++ b/src/processing/reads.jl
@@ -1,13 +1,7 @@
 
 """
     process_geometry_targets(
-        targets::Targets,
-        EPSG_code::Int16,
-        resolution::Float64 = 0.0001
-    )
-    process_geometry_targets(
         geometries::Vector{AG.IGeometry{AG.wkbPolygon}},
-        disturbance_gdf::DataFrame,
         EPSG_code::Int16,
         resolution::Float64 = 0.0001
     )
@@ -15,9 +9,7 @@
 Read and process target location geometries to generate a rasterized representation.
 
 # Arguments
-- `targets`: The object containing target locations and disturbance polygons.
 - `geometries`: A vector of geometries representing target locations.
-- `disturbance_gdf`: A DataFrame containing disturbance polygons.
 - `EPSG_code`: The EPSG code for the coordinate reference system.
 - `resolution`: The resolution for the rasterization process.
 
@@ -25,56 +17,24 @@ Read and process target location geometries to generate a rasterized representat
 - A rasterized representation of the target locations.
 """
 function process_geometry_targets(
-    targets::Targets,
-    EPSG_code::Int16,
-    resolution::Float64 = 0.0001 #! Hardcoded for now, but should be set -> in config file?
-)
-    # Compute centroids from the geometries in the GeoDataFrame
-    target_centroids = AG.centroid.(targets.gdf.geometry)
-    target_centroid_pts = (
-        p -> Point{2,Float64}(p[1:2])).(
-        AG.getpoint.(target_centroids, 0)
-    )
-
-    env_disturbance_values = get_disturbance_value.(
-        target_centroid_pts,
-        Ref(targets.disturbance_gdf)
-    )
-    targets_pts_tuple = [(t[1], t[2]) for t in target_centroid_pts]
-
-    return Rasters.rasterize(
-        last,
-        targets_pts_tuple;
-        res = resolution,
-        missingval = -9999.0,
-        fill = env_disturbance_values,
-        crs = EPSG(EPSG_code)
-    )
-end
-function process_geometry_targets(
     geometries::Vector{AG.IGeometry{AG.wkbPolygon}},
-    disturbance_gdf::DataFrame,
     EPSG_code::Int16,
-    resolution::Float64 = 0.0001 #! Hardcoded for now, but should be set -> in config file?
-)
+    resolution::Float64 = 0.0001
+)::Raster{Int}
     # Compute centroids from the geometries
     target_centroids = AG.centroid.(geometries)
     target_centroid_pts = (
         p -> Point{2,Float64}(p[1:2])).(
         AG.getpoint.(target_centroids, 0)
     )
-    env_disturbance_values = get_disturbance_value.(
-        target_centroid_pts,
-        Ref(disturbance_gdf)
-    )
     targets_pts_tuple = [(t[1], t[2]) for t in target_centroid_pts]
 
     return Rasters.rasterize(
         last,
         targets_pts_tuple;
         res = resolution,
-        missingval = -9999.0,
-        fill = env_disturbance_values, #! Revert back to 1?
+        missingval = 0,
+        fill = 1,
         crs = EPSG(EPSG_code)
     )
 end


### PR DESCRIPTION
Apply 3d kmeans for *disturbance* clustering.
- Disturbance values (i.e., wave data at each point) used to create additional correlation between points
- Random number `k_d` clusters generated (within bounds) to vary the magnitude of disturbance
- Reverts clustering calcs to euclidean from haversine