### PR TITLE
Disturbances affect clustering of unvisited deployment locations

### DIFF
--- a/src/HierarchicalRouting.jl
+++ b/src/HierarchicalRouting.jl
@@ -42,6 +42,7 @@ export Plot
 
 export load_problem, initial_solution, improve_solution
 
-export cluster_problem, nearest_neighbour, two_opt, tender_sequential_nearest_neighbour
+export cluster_problem, nearest_neighbour, two_opt, tender_sequential_nearest_neighbour,
+    disturb_clusters
 
 end

--- a/src/HierarchicalRouting.jl
+++ b/src/HierarchicalRouting.jl
@@ -32,6 +32,7 @@ include("optimization/metric_calcs.jl")
 include("optimization/solution_assessment.jl")
 
 include("problem/solve_problem.jl")
+include("problem/disturbance_events.jl")
 
 include("plotting/plots.jl")
 

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -11,6 +11,35 @@ using Random
 end
 
 """
+    generate_cluster_df(
+        clusters::Vector{Cluster},
+        depot::Point{2, Float64}
+    )::DataFrame
+
+Generate a DataFrame representing clusters vector containing the cluster centroids and their
+IDs.
+
+# Arguments
+- `clusters`: A vector of `Cluster` objects.
+- `depot`: A point representing the start/end of the route.
+
+# Returns
+- A DataFrame with the clusters: ID's and lon/lat of centroids.
+"""
+function generate_cluster_df(
+    clusters::Vector{Cluster},
+    depot::Point{2, Float64}
+)::DataFrame
+
+    cluster_centroids_df::DataFrame = DataFrame(
+        id  = [0; 1:length(clusters)],
+        lon = [depot[1]; [clust.centroid[1] for clust in clusters]],
+        lat = [depot[2]; [clust.centroid[2] for clust in clusters]]
+    )
+    return cluster_centroids_df
+end
+
+"""
     apply_kmeans_clustering(
         raster::Raster{Int, 2}, k::Int8; tol::Float64=1.0
     )::Raster{Int64, 2}

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -30,7 +30,6 @@ function generate_cluster_df(
     clusters::Vector{Cluster},
     depot::Point{2, Float64}
 )::DataFrame
-
     cluster_centroids_df::DataFrame = DataFrame(
         id  = [0; 1:length(clusters)],
         lon = [depot[1]; [clust.centroid[1] for clust in clusters]],

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -95,13 +95,10 @@ function apply_kmeans_clustering(
     # Assign the disturbance value to every node in the cluster
     disturbance_scores .= cluster_means[disturbance_clusters.assignments]
 
-    # create a threshold to remove nodes with a score above the threshold
-    #? change distribution to make threshold more likely to be higher
-    disturbance_magnitude = minimum(disturbance_scores) +
-        rand()*(maximum(disturbance_scores) - minimum(disturbance_scores))
+    # remove nodes with the highest disturbance score
+    max_disturbance_score = maximum(disturbance_scores)
+    surviving_mask = disturbance_scores .!= max_disturbance_score
 
-    # Remove nodes with a score above the threshold
-    surviving_mask = disturbance_scores .<= disturbance_magnitude
     coordinates_array_2d_disturbed = coordinates_array_3d[1:2, surviving_mask]
     indices = indices[surviving_mask]
 

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -16,7 +16,7 @@ end
     )::Raster{Int64, 2}
     apply_kmeans_clustering(
         raster::Raster{Float64, 2}, k::Int8; tol::Float64=1.0
-    )::Raster{Int64, 2}
+    )::Raster{Int, 2}
 
 Cluster targets sites by applying k-means to target (non-zero) cells in a raster.
 - Float64 raster is assumed to contain disturbance values, addressed buy 3d clustering

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -201,15 +201,12 @@ function calculate_cluster_centroids(
     cluster_ids=[]
 )::Vector{Cluster}
     unique_clusters = Vector{Int64}(undef, 0)
+    valid_clusters = unique(clusters_raster[clusters_raster .!= clusters_raster.missingval])
 
-    if isempty(cluster_ids)
-        unique_clusters = clusters_raster[clusters_raster .!= clusters_raster.missingval]
-        unique_clusters = sort(unique(unique_clusters))
-    else
-        if length(cluster_ids) != maximum(clusters_raster)
-            error("Length of cluster IDs given do not match number of clusters in raster.")
-        end
-        unique_clusters = cluster_ids
+    unique_clusters = isempty(cluster_ids) ? sort(valid_clusters) : cluster_ids
+
+    if !isempty(cluster_ids) && length(cluster_ids) != length(valid_clusters)
+        error("Length of cluster IDs given do not match number of clusters in raster.")
     end
 
     clusters_vector = Vector{Cluster}(undef, length(unique_clusters))
@@ -218,7 +215,8 @@ function calculate_cluster_centroids(
     y_coords = clusters_raster.dims[2]
 
     for (id, ex_id) in enumerate(unique_clusters)
-        nodes = [(x_coords[i[1]], y_coords[i[2]]) for i in findall(==(id), clusters_raster)]
+        node_indices = findall(==(ex_id), clusters_raster)
+        nodes = [(x_coords[i[1]], y_coords[i[2]]) for i in node_indices]
         col_cent = mean([node[1] for node in nodes])
         row_cent = mean([node[2] for node in nodes])
 

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -100,7 +100,7 @@ function apply_kmeans_clustering(
     coordinates_array_3d = Matrix{Float64}(undef, 3, n)
     coordinates_array_3d[1, :] .= raster.dims[1][getindex.(indices, 1)]
     coordinates_array_3d[2, :] .= raster.dims[2][getindex.(indices, 2)]
-    coordinates_array_3d[3, :] .= [raster[i] for i in indices]
+    coordinates_array_3d[3, :] .= raster[indices]
 
     # Create k_d clusters to create disturbance on subset
     k_d_lower = min(n, k+1)
@@ -116,15 +116,17 @@ function apply_kmeans_clustering(
 
     # Create a score based on the disturbance values for each cluster
     disturbance_scores = Vector{Float64}(undef, length(indices))
-    # Calculate the mean disturbance value for each cluster
-    cluster_means = [
+    # Calculate the mean disturbance value for each cluster with stochastic perturbation
+    w = 1.0 # weight for the environmental disturbance value
+    t = 1.0 # perturbation weighting factor
+    cluster_disturbance_vals = w*[
         mean(coordinates_array_3d[3, disturbance_clusters.assignments .== i])
         for i in 1:k_d
-    ]
+    ] .+ t*rand(-1.0:0.01:1.0, k_d)
     # Assign the disturbance value to every node in the cluster
-    disturbance_scores .= cluster_means[disturbance_clusters.assignments]
+    disturbance_scores .= cluster_disturbance_vals[disturbance_clusters.assignments]
 
-    # remove nodes with the highest disturbance score
+    # remove nodes with the highest disturbance score - i.e. one cluster
     max_disturbance_score = maximum(disturbance_scores)
     surviving_mask = disturbance_scores .!= max_disturbance_score
 

--- a/src/problem/disturbance_events.jl
+++ b/src/problem/disturbance_events.jl
@@ -42,6 +42,9 @@ function disturb_clusters(
         disturbance_raster,
         Int8(num_clusters);
     )
+    if all(x -> x == reclustered_disturbed_targets.missingval, reclustered_disturbed_targets)
+        return remaining_clusters
+    end
     disturbed_clusters = calculate_cluster_centroids(
         reclustered_disturbed_targets;
         cluster_ids=getfield.(remaining_clusters, :id)

--- a/src/problem/disturbance_events.jl
+++ b/src/problem/disturbance_events.jl
@@ -25,10 +25,12 @@ function disturb_clusters(
     num_clusters = length(remaining_clusters)
     remaining_nodes = [node for cluster in remaining_clusters for node in cluster.nodes]
 
-    # mask df to only include nodes in the remaining clusters
-    filtered_df = DataFrame()
-    for cluster in remaining_clusters
-        append!(filtered_df, filter(row -> row.node in cluster.nodes, disturbance_df))
+    # Filter the disturbance_df so that it only includes rows with nodes in remaining_nodes
+    filtered_df = filter(row -> row.node in remaining_nodes, disturbance_df)
+
+    if nrow(filtered_df) != length(remaining_nodes)
+        @warn "Warning: Expected $(length(remaining_nodes)) nodes, but filtered df contains $(nrow(filtered_df))"
+        #? Why mismatch? Nodes in exclusions? Why not previously identified?
     end
 
     disturbance_raster = Rasters.rasterize(

--- a/src/problem/disturbance_events.jl
+++ b/src/problem/disturbance_events.jl
@@ -21,7 +21,6 @@ function disturb_clusters(
     disturbance_df::DataFrame;
     res::Float64 = 0.0001
 )::Vector{Cluster}
-
     num_clusters = length(remaining_clusters)
     remaining_nodes = [node for cluster in remaining_clusters for node in cluster.nodes]
 

--- a/src/problem/disturbance_events.jl
+++ b/src/problem/disturbance_events.jl
@@ -40,15 +40,22 @@ function disturb_clusters(
         missingval = -9999.0,
         fill = filtered_df.wave_value,
     )
-    reclustered_disturbed_targets = apply_kmeans_clustering(
+    disturbed_targets = apply_kmeans_clustering(
         disturbance_raster,
         Int8(num_clusters);
     )
-    if all(x -> x == reclustered_disturbed_targets.missingval, reclustered_disturbed_targets)
+    if all(x -> x == disturbed_targets.missingval, disturbed_targets)
         return remaining_clusters
     end
+
+    # Update the cluster assignments based on previous numbering
+    updated_disturbed_targets = update_cluster_assignments(
+        disturbed_targets,
+        Dict(c.id => c.centroid for c in remaining_clusters)
+    )
+
     disturbed_clusters = calculate_cluster_centroids(
-        reclustered_disturbed_targets;
+        updated_disturbed_targets;
         cluster_ids=getfield.(remaining_clusters, :id)
     )
 

--- a/src/problem/disturbance_events.jl
+++ b/src/problem/disturbance_events.jl
@@ -1,0 +1,51 @@
+
+"""
+    disturb_clusters(
+    remaining_clusters::Vector{Cluster},
+    disturbance_df::DataFrame;
+    res::Float64 = 0.0001
+    )
+
+Disturb the clusters by randomly removing nodes from them.
+
+# Arguments
+- `remaining_clusters`: A vector of `Cluster` objects representing clusters to be disturbed.
+- `disturbance_df`: A DataFrame containing disturbance data for each node.
+- `res`: The resolution of the raster to be created from the disturbance data.
+
+# Returns
+A vector of `Cluster` objects with nodes removed from them.
+"""
+function disturb_clusters(
+    remaining_clusters::Vector{Cluster},
+    disturbance_df::DataFrame;
+    res::Float64 = 0.0001
+)::Vector{Cluster}
+
+    num_clusters = length(remaining_clusters)
+    remaining_nodes = [node for cluster in remaining_clusters for node in cluster.nodes]
+
+    # mask df to only include nodes in the remaining clusters
+    filtered_df = DataFrame()
+    for cluster in remaining_clusters
+        append!(filtered_df, filter(row -> row.node in cluster.nodes, disturbance_df))
+    end
+
+    disturbance_raster = Rasters.rasterize(
+        last,
+        [(t[1],t[2]) for t in filtered_df.node];
+        res = res,
+        missingval = -9999.0,
+        fill = filtered_df.wave_value,
+    )
+    reclustered_disturbed_targets = apply_kmeans_clustering(
+        disturbance_raster,
+        Int8(num_clusters);
+    )
+    disturbed_clusters = calculate_cluster_centroids(
+        reclustered_disturbed_targets;
+        cluster_ids=getfield.(remaining_clusters, :id)
+    )
+
+    return disturbed_clusters
+end

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -38,20 +38,39 @@ function initial_solution(problem::Problem)::MSTSolution
         ms_soln_2opt.cluster_sequence.id
     )
     tender_soln = Vector{TenderSolution}(undef, length(clust_seq))
+    cluster_set::Vector{Vector{Cluster}} = Vector{Vector{Cluster}}(undef, length(clust_seq))
+    disturbed_clusters::Vector{Cluster} = Vector{Cluster}(undef, length(clust_seq))
 
     for (i, cluster_id) in enumerate(clust_seq)
         start_waypoint::Point{2, Float64} =  ms_soln_2opt.route.nodes[2 * i]
         end_waypoint::Point{2, Float64} =  ms_soln_2opt.route.nodes[2 * i + 1]
         @info "$(i): Clust $(cluster_id) from $(start_waypoint) to $(end_waypoint)"
 
+        disturbed_clusters = i==1 ? clusters : cluster_set[i-1]
+
+        if i ∈ (2,4) #! disturbance events are hardcoded for now at/before 2 and 4
+            disturbed_clusters = sort(
+                vcat(
+                    disturbed_clusters[clust_seq][1:i-1],
+                    disturb_clusters(
+                        disturbed_clusters[clust_seq][i:end],
+                        problem.targets.disturbance_gdf
+                    )
+                ),
+                by = x -> x.id
+            )
+        end
+        cluster_set[i] = disturbed_clusters
+
+        #? order by deployment sequence, rather than ID
         tender_soln[i] = tender_sequential_nearest_neighbour(
-            clusters[cluster_id],
+            disturbed_clusters[cluster_id],
             (start_waypoint, end_waypoint),
             problem.tenders.number, problem.tenders.capacity, problem.tenders.exclusion
         )
     end
 
-    return MSTSolution(clusters, ms_soln_2opt, tender_soln)
+    return MSTSolution(clusters, cluster_set, ms_soln_2opt, tender_soln)
 end
 
 """

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -16,12 +16,7 @@ Best total MSTSolution found
 function initial_solution(problem::Problem)::MSTSolution
     # Load problem data
     clusters::Vector{Cluster} = cluster_problem(problem);
-
-    cluster_centroids_df::DataFrame = DataFrame(
-        id  = [0; 1:length(clusters)],
-        lon = [problem.depot[1]; [clust.centroid[1] for clust in clusters]],
-        lat = [problem.depot[2]; [clust.centroid[2] for clust in clusters]]
-    )
+    cluster_centroids_df::DataFrame = generate_cluster_df(clusters, problem.depot)
 
     # Nearest Neighbour to generate initial mothership route & matrix
     ms_soln_NN::MothershipSolution = nearest_neighbour(

--- a/src/processing/reads.jl
+++ b/src/processing/reads.jl
@@ -4,7 +4,7 @@
         geometries::Vector{AG.IGeometry{AG.wkbPolygon}},
         EPSG_code::Int16,
         resolution::Float64 = 0.0001
-    )
+    )::Raster{Int}
 
 Read and process target location geometries to generate a rasterized representation.
 

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -20,6 +20,7 @@ end
 
 struct MSTSolution
     clusters::Vector{Cluster}
+    disturbed_cluster_sets::Vector{Vector{Cluster}}
     mothership::MothershipSolution
     tenders::Vector{TenderSolution}
 end


### PR DESCRIPTION
Disturbances generated twice before 2nd and 4th clusters ('magic number' arbitrary locations for now).

Removes nodes that have been *clustered* for disturbances based on their disturbance scores. These nodes have been grouped by score, averaged within the group, and perturbed as a group by a random arithmetic operator. 
The group with the highest score is removed.
- Cluster ID consistency is ensured (before and after disturbances)
- Warnings are generated if too few locations remain based on required number of future deployment clusters to be visited
- `disturbed_cluster_sets` atrribute introduced to MSTSolution struct