### PR TITLE
Corrects feasible routes around polygons to follow shortest feasible path

### DIFF
--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -41,13 +41,13 @@ end
 
 """
     apply_kmeans_clustering(
-        raster::Raster{Int, 2},
+        points::Vector{Point{2, Float64}},
         k::Int8,
         current_location::Point{2, Float64},
         exclusions::DataFrame;
         tol::Float64=1.0,
         dist_weighting::Float64=2E-5
-    )::Raster{Int64, 2}
+    )::DataFrame
     apply_kmeans_clustering(
         raster::Raster{Float64, 2},
         k::Int8,
@@ -57,13 +57,14 @@ end
         dist_weighting::Float64=2E-5
     )::Raster{Int64, 2}
 
-Cluster targets sites by applying k-means to target (non-zero) cells in a raster.
-- Float64 raster is assumed to contain disturbance values, addressed buy 3d clustering
-- Int raster is assumed to contain cluster ID values, addressed by 2d spatial clustering.
-Clustering considers feasible distances from the current location as a 3rd dimenseion, and
+Cluster targets locations by applying k-means to target (non-zero) cells in a raster.
+- Vector of points is assumed to contain target locations
+- Float64 raster is assumed to contain disturbance values
+Clustering considers feasible distances from the current location as a 3rd dimension, and
     excludes points in exclusion zones.
 
 # Arguments
+- `points`: Vector of points representing target locations.
 - `raster`: Raster containing the target geometries.
 - `k`: Number of clusters to create.
 - `current_location`: Current location of the mothership.
@@ -73,22 +74,17 @@ Clustering considers feasible distances from the current location as a 3rd dimen
     against lat/lons.
 
 # Returns
-A raster containing new clusters, with cluster IDs assigned to each target site.
+- A DataFrame with the clustered points and their corresponding cluster IDs.
+- A raster containing new clusters, with cluster IDs assigned to each target locations.
 """
 function apply_kmeans_clustering(
-    raster::Raster{Int, 2},
+    points::Vector{Point{2, Float64}},
     k::Int8,
     current_location::Point{2, Float64},
     exclusions::DataFrame;
     tol::Float64=1.0,
     dist_weighting::Float64=2E-5
-)::Raster{Int64, 2}
-    indices::Vector{CartesianIndex{2}} = findall(x -> x != raster.missingval, raster)
-    rows::Vector{Int64} = getindex.(indices, 1)
-    cols::Vector{Int64} = getindex.(indices, 2)
-
-    points = Point{2,Float64}.(zip(raster.dims[1][rows], raster.dims[2][cols]))
-
+)::DataFrame
     dist_vector = dist_weighting .* get_feasible_distances(
         current_location,
         points,
@@ -106,9 +102,10 @@ function apply_kmeans_clustering(
 
     clustering = kmeans(coordinates_array, k; tol=tol, rng=Random.seed!(1))
 
-    clustered_targets::Raster{Int64, 2} = similar(raster, Int64)
-    clustered_targets .= clustered_targets.missingval
-    clustered_targets[indices[feasible_idxs]] .= clustering.assignments
+    clustered_targets::DataFrame = DataFrame(
+        id = clustering.assignments,
+        geometry = feasible_points
+    )
 
     return clustered_targets
 end
@@ -156,10 +153,12 @@ function apply_kmeans_clustering(
     # Calculate the mean disturbance value for each cluster with stochastic perturbation
     w = 1.0 # weight for the environmental disturbance value
     t = 1.0 # perturbation weighting factor
-    cluster_disturbance_vals = w*[
-        mean(coordinates_array_3d[3, disturbance_clusters.assignments .== i])
-        for i in 1:k_d
-    ] .+ t*rand(-1.0:0.01:1.0, k_d)
+    cluster_disturbance_vals =
+        w * [
+            mean(coordinates_array_3d[3, disturbance_clusters.assignments .== i])
+            for i in 1:k_d
+        ] .+
+        t * rand(-1.0:0.01:1.0, k_d)
     # Assign the disturbance value to every node in the cluster
     disturbance_scores .= cluster_disturbance_vals[disturbance_clusters.assignments]
 
@@ -280,14 +279,18 @@ end
 
 """
     calculate_cluster_centroids(
-    cluster_raster::Raster{Int64, 2};
-    cluster_ids=[]
-)::Vector{Cluster}
+        cluster_raster::Raster{Int64, 2};
+        cluster_ids=[]
+    )::Vector{Cluster}
+    function calculate_cluster_centroids(
+        clusters::DataFrame
+    )::Vector{Cluster}
 
 Calculate the centroids of the clusters in the raster.
 
 # Arguments
 - `clusters_raster`: Raster containing the cluster IDs.
+- `clusters`: DataFrame containing the cluster IDs and their geometries.
 - `cluster_ids`: Optional list of cluster IDs to assign to the clusters.
 
 # Returns
@@ -325,122 +328,25 @@ function calculate_cluster_centroids(
     end
     return clusters_vector
 end
-
-"""
-    generate_target_clusters(
-        clustered_targets_path::String,
-        k::Int8,
-        cluster_tolerance::Float64,
-        suitable_targets_all_path::String,
-        suitable_threshold::Float64,
-        target_subset_path::String,
-        subset::DataFrame,
-        EPSG_code::Int16
-    )::Vector{Cluster}
-
-Generate a clustered targets raster by reading in the suitable target data,
-applying thresholds and cropping to a target subset area, and then clustering.
-
-# Arguments
-- `clustered_targets_path`: Path to the clustered targets raster.
-- `k`: Number of clusters to create.
-- `cluster_tolerance`: Tolerance for kmeans convergence.
-- `suitable_targets_all_path`: Path to the suitable targets raster.
-- `suitable_threshold`: Threshold for suitable targets.
-- `target_subset_path`: Path to the target subset raster.
-- `subset`: DataFrame containing the target geometries.
-- `EPSG_code`: EPSG code for the target geometries.
-
-# Returns
-A vector of Cluster objects.
-"""
-function generate_target_clusters(
-    clustered_targets_path::String,
-    k::Int8,
-    cluster_tolerance::Float64,
-    targets::Targets,
-    suitable_threshold::Float64,
-    target_subset_path::String,
-    subset::DataFrame,
-    EPSG_code::Int16,
-    current_location::Point{2, Float64},
-    exclusions::DataFrame;
+function calculate_cluster_centroids(
+    clusters::DataFrame
 )::Vector{Cluster}
-    cluster_raster = process_targets(
-        targets,
-        k,
-        cluster_tolerance,
-        suitable_threshold,
-        target_subset_path,
-        subset,
-        EPSG_code,
-        current_location,
-        exclusions
-    )
+    unique_clusters = sort(unique(clusters.id))
 
-    write(clustered_targets_path, cluster_raster; force = true)
+    clusters_vector = Vector{Cluster}(undef, length(unique_clusters))
 
-    return calculate_cluster_centroids(cluster_raster)
-end
+    for id in unique_clusters
+        cluster_mask = clusters.id .== id
+        clustered_points = clusters.geometry[cluster_mask]
 
-"""
-    process_targets(
-        targets::Targets,
-        k::Int8,
-        cluster_tolerance::Float64,
-        suitable_targets_all_path::String,
-        suitable_threshold::Float64,
-        target_subset_path::String,
-        subset::DataFrame,
-        EPSG_code::Int16
-    )::Raster{Int64}
+        lon_cent = mean(getindex.(clustered_points, 1))
+        lat_cent = mean(getindex.(clustered_points, 2))
 
-Generate a clustered targets raster by reading in the suitable target location data,
-applying thresholds and cropping to a target subset, and then clustering.
-
-# Arguments
-- `targets`: The targets object containing the target geometries.
-- `k`: The number of clusters.
-- `cluster_tolerance`: The cluster tolerance.
-- `suitable_threshold`: The suitable targets threshold.
-- `target_subset_path`: The path to the target subset raster.
-- `subset`: The DataFrame containing the study area boundary.
-- `EPSG_code`: The EPSG code for the study area.
-
-# Returns
-The clustered targets raster, classified by cluster ID number.
-"""
-function process_targets(
-    targets::Targets,
-    k::Int8,
-    cluster_tolerance::Float64,
-    suitable_threshold::Float64,
-    target_subset_path::String,
-    subset::DataFrame,
-    EPSG_code::Int16,
-    current_location::Point{2, Float64},
-    exclusions::DataFrame;
-)::Raster{Int64}
-    if endswith(targets.path, ".geojson")
-        suitable_targets_all = process_geometry_targets(
-            targets.gdf.geometry,
-            EPSG_code
-        )
-    else
-        suitable_targets_all = process_raster_targets(
-            targets,
-            EPSG_code,
-            suitable_threshold
+        clusters_vector[id] = Cluster(
+            id = id,
+            centroid = Point{2, Float64}(lon_cent, lat_cent),
+            nodes = clustered_points
         )
     end
-
-    suitable_targets_subset::Raster{Int} = Rasters.crop(suitable_targets_all, to=subset.geom)
-    if !isfile(target_subset_path)
-        write(target_subset_path, suitable_targets_subset; force=true)
-    end
-
-    clustered_targets::Raster{Int64, 2} = apply_kmeans_clustering(
-        suitable_targets_subset, k, current_location, exclusions; tol=cluster_tolerance
-    )
-    return clustered_targets
+    return clusters_vector
 end

--- a/src/problem/disturbance_events.jl
+++ b/src/problem/disturbance_events.jl
@@ -39,7 +39,7 @@ function disturb_clusters(
         [(t[1],t[2]) for t in filtered_df.node];
         res = res,
         missingval = -9999.0,
-        fill = filtered_df.wave_value,
+        fill = filtered_df.disturbance_value,
     )
     disturbed_targets = apply_kmeans_clustering(
         disturbance_raster,

--- a/src/processing/processing.jl
+++ b/src/processing/processing.jl
@@ -50,15 +50,15 @@ Return a DataFrame containing nodes and their corresponding disturbance values.
 
 # Arguments
 - `nodes`: A vector of nodes (points).
-- `disturbance_data`: The disturbance data containing wave values.
+- `disturbance_data`: The disturbance data containing disturbance values.
 
 # Returns
-- A DataFrame with two columns: `node` and `wave_value`.
+- A DataFrame with two columns: `node` and `disturbance_value`.
 """
 function create_disturbance_data_dataframe(
     nodes::Vector{Point{2, Float64}},
     disturbance_data::DataFrame
 )::DataFrame
     disturbance_values = get_disturbance_value.(nodes, Ref(disturbance_data))
-    return DataFrame(node = nodes, wave_value = disturbance_values)
+    return DataFrame(node = nodes, disturbance_value = disturbance_values)
 end

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -342,9 +342,10 @@ function build_network!(
     )
 
     # Preallocate enough extra capacity assuming candidate point is added
-    sizehint!(points_from, length(points_from) + length(candidates))
-    sizehint!(points_to, length(points_to) + length(candidates))
-    sizehint!(exclusion_idxs, length(exclusion_idxs) + length(candidates))
+    length_vectors_new = length(points_from) + length(candidates)
+    sizehint!(points_from, length_vectors_new)
+    sizehint!(points_to, length_vectors_new)
+    sizehint!(exclusion_idxs, length_vectors_new)
 
     for (vertex, next_exclusion_idx) in zip(candidates, next_exclusion_idxs)
 

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -223,8 +223,9 @@ function shortest_feasible_path(
                 Ref(exclusions)
             )
         ]
-
-        if !isempty(visible_vertices)
+            # filter out initial point from visible vertices
+            visible_vertices = unique(filter(v -> v != initial_point, visible_vertices))
+            if !isempty(visible_vertices)
             # Connect initial point to every visible polygon vertex
             n_vis_verts = length(visible_vertices)
 

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -451,7 +451,8 @@ function build_graph(
     # Only add polygon edges and extra visible connections if:
     # 1. A polygon is provided, AND
     # 2. Direct line/path from initial_point -> final_point is NOT visible (i.e. obstructed)
-    if is_polygon && !is_visible(initial_point, final_point, final_polygon)
+    if is_polygon
+        if !is_visible(initial_point, final_point, final_polygon)
 
         # Get vectors of polygon vertices (from, to) and their corresponding indices
         i_vertices::Vector{Point{2, Float64}} = poly_vertices[1:end-1]
@@ -487,7 +488,16 @@ function build_graph(
                 graph,
                 pt_to_idx[poly_vertices[end]],
                 pt_to_idx[poly_vertices[1]],
-                haversine(poly_vertices[end], poly_vertices[1])
+                    haversine(poly_vertices[end], poly_vertices[1])
+                )
+            end
+        else
+            # Connect initial point to final point if visible
+            add_edge!(
+                graph,
+                pt_to_idx[initial_point],
+                pt_to_idx[final_point],
+                haversine(initial_point, final_point)
             )
         end
     end

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -199,7 +199,6 @@ function shortest_feasible_path(
     points_from = Point{2,Float64}[]
     points_to = Point{2,Float64}[]
     exclusion_idxs = Int[]
-
     # If initial point is not within an exclusion zone
     if iszero(initial_exclusion_idx)
         build_network!(
@@ -260,7 +259,7 @@ function shortest_feasible_path(
         points_to,
         exclusions,
         iszero(final_exclusion_idx) ?
-        AG.creategeom(AG.wkbPolygon) : exclusions[final_exclusion_idx,:geometry],
+            AG.creategeom(AG.wkbPolygon) : exclusions[final_exclusion_idx, :geometry],
         initial_point,
         final_point
     )

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -567,5 +567,5 @@ function collect_polygon_vertices(polygon::AG.IGeometry{AG.wkbPolygon}
     # poly_vertices = Point{2, Float64}.(points_x[target_points_mask], points_y[target_points_mask])
     # n_pts = length(poly_vertices)
 
-    return pts
+    return unique(pts)
 end

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -251,6 +251,7 @@ function shortest_feasible_path(
         end
 
         # Get widest points to final point on polygon contianing initial point
+        #! Note that to/from points are inverted in find_widest_points() because initial point is in convex hull of polygon
         widest_verts = find_widest_points(
             final_point,
             initial_point,

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -373,13 +373,11 @@ function build_network!(
     sizehint!(exclusion_idxs, length_vectors_new)
 
     for (vertex, next_exclusion_idx) in zip(candidates, next_exclusion_idxs)
-
-        if isnothing(vertex) || vertex == current_point
-            continue
-        end
-
-        # If edge already exists in network, skip
-        if (current_point, vertex) ∈ zip(points_from, points_to)
+        # If vertex is nothing, or already visited/explored,
+        # or edge already exists in network, skip
+        if isnothing(vertex) ||
+            vertex == current_point ||
+            (current_point, vertex) ∈ zip(points_from, points_to)
             continue
         end
 

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -320,6 +320,15 @@ end
 
 Build a network of points to connect to each other.
 Vectors `points_from`, `points_to`, and `exclusion_idxs` are modified in place.
+
+# Arguments
+- `points_from`: Vector of points to connect from.
+- `points_to`: Vector of points to connect to.
+- `exclusion_idxs`: Vector of exclusion zone indices.
+- `current_point`: Current point to connect from.
+- `final_point`: Final point to connect to.
+- `exclusions`: DataFrame containing exclusion zones.
+- `final_exclusion_idx`: Index of the final exclusion zone.
 """
 function build_network!(
     points_from::Vector{Point{2, Float64}},


### PR DESCRIPTION
- Connects all **visible** polygon vertices, rather than only **adjacent** vertices to avoid following crevices unnecessarily, when:
  - final point is contained within a convex hull (and not visible), in `build_graph()`; and
  - initial point is contained within a convex hull, in `shortest_feasible_path()`.
- Includes `else` statement in `build_graph()` to catch scenarios where `initial_point` and `final_point` are visible.

Closes #27 