### PR TITLE
Adjusts exclusions to prevent target exclusion

### DIFF
--- a/src/problem/problem_setup.jl
+++ b/src/problem/problem_setup.jl
@@ -195,6 +195,10 @@ function load_problem(target_path::String)::Problem
     unionize_overlaps!(t_exclusions)
     #? Redundant 2nd call to simplify_exclusions!()
     filter_and_simplify_exclusions!(t_exclusions, min_area=1E-7, simplify_tol=5E-4)
+    t_exclusions = adjust_exclusions(
+        targets.points.geometry,
+        t_exclusions
+    )
 
     mothership = Vessel(
         exclusion = ms_exclusions,
@@ -286,4 +290,67 @@ function filter_within_bbox(
         gdf
     )
     return filtered_gdf
+end
+
+function adjust_exclusions(
+    points::Vector{Point{2, Float64}},
+    exclusions::DataFrame
+)::DataFrame
+    exclusion_geometries = exclusions.geometry
+    poly_adjustment_mask = point_in_exclusion.(points, Ref(exclusions))
+    contained_points = points[poly_adjustment_mask]
+    containing_poly_ids = containing_exclusion.(contained_points, Ref(exclusions))
+
+    # Dictionary to map exclusion polygons to contained points
+    polygon_points_map = Dict{Int, Vector{Point{2, Float64}}}()
+    for (point, poly_id) in zip(contained_points, containing_poly_ids)
+        if !haskey(polygon_points_map, poly_id)
+            polygon_points_map[poly_id] = Vector{Point{2, Float64}}()
+        end
+        push!(polygon_points_map[poly_id], point)
+    end
+
+    updated_vertices = Dict{Int, Vector{Tuple{Float64, Float64}}}()
+    for (poly_id, points_to_insert) in polygon_points_map
+        @info "Processing polygon ID: $poly_id"
+        polygon = exclusion_geometries[poly_id]
+        polygon_points = AG.getgeom(polygon, 0)
+        n_vertices = AG.ngeom(polygon_points)
+        polygon_vertices = [AG.getpoint(polygon_points, i)[1:2] for i in 0:n_vertices-1]
+
+        for point in points_to_insert
+            min_dist = Inf
+            insert_index = n_vertices
+
+            for i in 1:n_vertices-1
+                p1 = Point{2,Float64}(polygon_vertices[i])
+                p2 = Point{2,Float64}(polygon_vertices[i+1])
+
+                # TODO: Use a more robust method to find the closest point on the edge
+                dist = (
+                    abs(p1[1] - point[1]) + abs(p1[2] - point[2])
+                    +
+                    abs(p2[1] - point[1]) + abs(p2[2] - point[2])
+                )
+
+                if dist < min_dist
+                    min_dist = dist
+                    insert_index = i
+                end
+            end
+            # Insert the point at index
+            pre_points = polygon_vertices[1:insert_index]
+            post_points = polygon_vertices[insert_index+1:n_vertices]
+
+            polygon_vertices = vcat(pre_points, [(point[1], point[2])], post_points)
+            n_vertices = length(polygon_vertices)
+        end
+        updated_vertices[poly_id] = polygon_vertices
+    end
+
+    for i in keys(polygon_points_map)
+        exclusions.geometry[i] = AG.createpolygon(updated_vertices[i])
+    end
+
+    return exclusions
 end

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -169,11 +169,23 @@ end
 function point_in_exclusion(point::Point{2, Float64}, exclusions::DataFrame)::Bool
     return any(AG.contains.(exclusions.geometry, Ref(AG.createpoint(point[1], point[2]))))
 end
+
+"""
+    containing_exclusion(point::Point{2, Float64}, exclusions::DataFrame)::Int
+
+Return the index of the exclusion zone that contains the point.
+
+# Arguments
+- `point`: Point to check.
+- `exclusions`: A DataFrame containing exclusion zone polygons.
+
+# Returns
+- Index of the first exclusion zone that contains the point, or 0 if not found.
+"""
+function containing_exclusion(point::Point{2, Float64}, exclusions::DataFrame)::Int
     point_ag = AG.createpoint(point[1], point[2])
-    return any(AG.contains.(exclusions.geometry, [point_ag]))
-end
-function point_in_exclusion(point::Point{2, Float64}, exclusion::AG.IGeometry)::Bool
-return any(AG.contains(exclusion, AG.createpoint(point[1], point[2])))
+    exclusion_idx = findfirst(AG.contains.(exclusions.geometry, [point_ag]))
+    return isnothing(exclusion_idx) ? 0 : exclusion_idx
 end
 
 """

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -145,8 +145,9 @@ function get_feasible_distances(
 end
 
 """
-    point_in_exclusion(point::Point{2, Float64}, exclusions::DataFrame)::Bool
     point_in_exclusion(point::Point{2, Float64}, exclusion::AG.IGeometry)::Bool
+    point_in_exclusion(point::Point{2, Float64}, exclusions::Vector{AG.IGeometry})::Bool
+    point_in_exclusion(point::Point{2, Float64}, exclusions::DataFrame)::Bool
 
 Check if a point is within an exclusion zone.
 
@@ -154,11 +155,20 @@ Check if a point is within an exclusion zone.
 - `point`: Point to check.
 - `exclusions::DataFrame`: A DataFrame containing exclusion zone polygons.
 - `exclusion::AG.IGeometry`: One exclusion zone polygon/geometry from a DataFrame.
+- `exclusions::Vector{AG.IGeometry}`: A vector of exclusion zone polygons/geometry.
 
 # Returns
 - `true` if point is within an exclusion zone, `false` otherwise.
 """
+function point_in_exclusion(point::Point{2, Float64}, exclusion::AG.IGeometry)::Bool
+    return any(AG.contains(exclusion, AG.createpoint(point[1], point[2])))
+end
+function point_in_exclusion(point::Point{2, Float64}, exclusions::Vector{AG.IGeometry})::Bool
+    return any(AG.contains.(exclusions, Ref(AG.createpoint(point[1], point[2]))))
+end
 function point_in_exclusion(point::Point{2, Float64}, exclusions::DataFrame)::Bool
+    return any(AG.contains.(exclusions.geometry, Ref(AG.createpoint(point[1], point[2]))))
+end
     point_ag = AG.createpoint(point[1], point[2])
     return any(AG.contains.(exclusions.geometry, [point_ag]))
 end


### PR DESCRIPTION
Ensures that target points are not wrongly excluded by simplified exclusion polygons by inserting target points found within polygons as new vertices.

Closes #15, #29 