### PR TITLE
Improves solution optimization with cross-cluster perturbation and node insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ solution_best, z_best = improve_solution(
     HierarchicalRouting.simulated_annealing,                        # opt_function
     HierarchicalRouting.critical_path,                              # objective_function
     HierarchicalRouting.perturb_swap_solution,                      # perturb_function
+    problem.mothership.exclusion,                                   # exclusion
     problem.tenders.exclusion;                                      # exclusion
 );
 ```

--- a/src/optimization/metric_calcs.jl
+++ b/src/optimization/metric_calcs.jl
@@ -37,7 +37,7 @@ function sortie_dist(
 )::Vector{Float64}
     sorties = filter(!isempty, sorties)
     n = length(sorties)
-    sortie_dist = Vector{Float64}(undef, n)
+    total_dist = Vector{Float64}(undef, n)
 
     for i in 1:n
         tour = sorties[i]
@@ -47,9 +47,9 @@ function sortie_dist(
         dist += m > 1 ? sum(getindex.(Ref(dist_matrix), tour[1:m-1], tour[2:m])) : 0.0
         dist += dist_matrix[tour[end], 1] # dist from last node back to depot
 
-        sortie_dist[i] = dist
+        total_dist[i] = dist
     end
-    return sortie_dist
+    return total_dist
 end
 
 """

--- a/src/optimization/metric_calcs.jl
+++ b/src/optimization/metric_calcs.jl
@@ -92,6 +92,35 @@ function tender_clust_dist(tenders::TenderSolution)::Vector{Float64}
 end
 
 """
+    tender_sortie_dist(sortie::Route)::Float64
+    tender_sortie_dist(
+        node_order::Vector{Int64},
+        dist_matrix::Matrix{Float64}
+    )::Float64
+
+# Arguments
+- `sortie`: Route object containing nodes and distance matrix.
+- `node_order`: Vector of node indices (not including the start and finish).
+- `dist_matrix`: Distance matrix between nodes, ordered by node index.
+
+# Returns
+The total distance of the sortie.
+"""
+function tender_sortie_dist(sortie::Route)::Float64
+    dist = sum(@view sortie.dist_matrix[1:end-1, 2:end])
+    return dist
+end
+function tender_sortie_dist(
+    node_order::Vector{Int64},
+    dist_matrix::Matrix{Float64}
+)::Float64
+    dist = dist_matrix[1, node_order[1]+1] # dist from start (node 1) to first node
+    dist += sum(@view dist_matrix[node_order[1:end-1] .+ 1, node_order[2:end] .+ 1])
+    dist += dist_matrix[node_order[end]+1, end] # dist from last deployment loc to end node
+    return dist
+end
+
+"""
     mothership_dist_between_clusts(route::Route)::Float64
 
 Compute the cost of the mothership route between clusters, not including across each cluster.

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -129,8 +129,10 @@ function perturb_swap_solution(
     sorties_a, sorties_b = tender_a.sorties, tender_b.sorties
 
     # Pick random sorties and ensure both have nodes
-    sortie_a_idx, sortie_b_idx = rand(1:length(sorties_a)), rand(1:length(sorties_b))
-    sortie_a, sortie_b = sorties_a[sortie_a_idx], sorties_b[sortie_b_idx]
+    sortie_a_idx = rand(1:length(tender_a.sorties))
+    sortie_b_idx = rand(1:length(tender_b.sorties))
+    sortie_a = deepcopy(tender_a.sorties[sortie_a_idx])
+    sortie_b = deepcopy(tender_b.sorties[sortie_b_idx])
 
     if isempty(sortie_a.nodes) || isempty(sortie_b.nodes)
         return soln

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -173,6 +173,31 @@ function perturb_swap_solution(
         for i in 1:length(tender_b.sorties)
     ]
 
+    # Update new clusters
+    new_clusters::Vector{Cluster} = deepcopy(soln.cluster_sets[end])
+
+    cluster_a_idx = tender_a.id
+    cluster_b_idx = tender_b.id
+    nodes_a = new_clusters[cluster_a_idx].nodes
+    nodes_b = new_clusters[cluster_b_idx].nodes
+
+    # Swap nodes between clusters
+    node_a_idx_clust = findfirst(isequal(node_a), nodes_a)
+    node_b_idx_clust = findfirst(isequal(node_b), nodes_b)
+    nodes_a[node_a_idx_clust] = node_b
+    nodes_b[node_b_idx_clust] = node_a
+
+    centroid_a, centroid_b = Point{2, Float64}.([
+        (mean(getindex.(nodes_a, 1)), mean(getindex.(nodes_a, 2))),
+        (mean(getindex.(nodes_b, 1)), mean(getindex.(nodes_b, 2)))
+    ])
+
+    new_clusters[cluster_a_idx], new_clusters[cluster_b_idx] = Cluster.(
+        [cluster_a_idx, cluster_b_idx],
+        [centroid_a, centroid_b],
+        [nodes_a, nodes_b],
+    )
+
     tenders_all::Vector{TenderSolution} = copy(soln.tenders)
     tenders_all[clust_a_seq_idx] = TenderSolution(
         tender_a.id,

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -274,11 +274,17 @@ end
     find_unallocated_nodes(
         soln::MSTSolution
     )::Set{Point{2, Float64}}
+    find_unallocated_nodes(
+        clusters::Vector{Cluster},
+        tenders::Vector{TenderSolution}
+    )::Set{Point{2, Float64}}
 
 Find nodes that are not allocated to any sortie in the solution.
 
 # Arguments
 - `soln`: Solution to find unallocated nodes in.
+- `clusters`: Vector of clusters.
+- `tenders`: Vector of tender solutions.
 
 # Returns
  A set of unallocated nodes.
@@ -288,6 +294,12 @@ function find_unallocated_nodes(
 )::Set{Point{2, Float64}}
     clusters = soln.cluster_sets[end]
     tenders = soln.tenders
+    return find_unallocated_nodes(clusters, tenders)
+end
+function find_unallocated_nodes(
+    clusters::Vector{Cluster},
+    tenders::Vector{TenderSolution}
+)::Set{Point{2, Float64}}
     cluster_sorties = getfield.(tenders, :sorties)
 
     all_nodes::Set{Point{2, Float64}} = Set(vcat(getfield.(clusters, :nodes)...))
@@ -296,9 +308,7 @@ function find_unallocated_nodes(
             getfield.(Base.Iterators.flatten(cluster_sorties), :nodes))
         )
     )
-    unallocated_nodes = setdiff(all_nodes, allocated_nodes)
-
-    return unallocated_nodes
+    return setdiff(all_nodes, allocated_nodes)
 end
 
 """

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -348,11 +348,6 @@ function insert_unallocated_node(
 
     for node in unallocated_nodes
         centroids = getfield.(clusters, :centroid)
-        within_range = haversine.(Ref(node), centroids) .< max_dist
-        cluster_mask = (min_tender_sorties .< t_cap) .& (within_range)
-        if !any(cluster_mask)
-            break
-        end
 
         # Find the closest cluster by shortest distance to ms path
         waypoint_distances = getindex.(shortest_feasible_path.(
@@ -363,6 +358,13 @@ function insert_unallocated_node(
         @views cluster_waypoint_distances =
             waypoint_distances[1:2:end] .+
             waypoint_distances[2:2:end]
+
+        cluster_mask = (min_tender_sorties .< t_cap) .&
+            (cluster_waypoint_distances .< max_dist)
+
+        if isempty(cluster_mask)
+            break
+        end
 
         # Find the closest cluster with available tender capacity to the unallocated node
         valid_idxs = findall(cluster_mask)

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -6,8 +6,15 @@
         exclusions::DataFrame = DataFrame();
         enforce_diff_sortie::Bool = false
     )::MSTSolution
+    perturb_swap_solution(
+        soln::MSTSolution,
+        cluster_pair::Tuple{Int, Int},
+        exclusions::DataFrame = DataFrame()
+    )::MSTSolution
 
-Perturb the solution by swapping two nodes in a cluster.
+Perturb the solution by swapping two nodes:
+- within a cluster, or
+- between two clusters.
 
 # Arguments
 - `soln`: Solution to perturb.
@@ -217,7 +224,7 @@ function simulated_annealing(
     temp_init::Float64 = 500.0,
     cooling_rate::Float64 = 0.95,
     static_limit::Int = 150
-)
+)::Tuple{MSTSolution, Float64}
     # Initialize best solution as initial
     soln_best = deepcopy(soln_init)
     obj_best = objective_function(soln_init)

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -40,7 +40,7 @@ function perturb_swap_solution(
         clust_seq_idx_target
 
     tender = deepcopy(soln.tenders[clust_seq_idx])
-    sorties = tender.sorties
+    sorties = deepcopy(tender.sorties)
 
     # If < 2 sorties in cluster, no perturbation possible
     if length(sorties) < 2

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -225,6 +225,37 @@ function perturb_swap_solution(
 end
 
 """
+    find_unallocated_nodes(
+        soln::MSTSolution
+    )::Set{Point{2, Float64}}
+
+Find nodes that are not allocated to any sortie in the solution.
+
+# Arguments
+- `soln`: Solution to find unallocated nodes in.
+
+# Returns
+ A set of unallocated nodes.
+"""
+function find_unallocated_nodes(
+    soln::MSTSolution
+)::Set{Point{2, Float64}}
+    clusters = soln.cluster_sets[end]
+    tenders = soln.tenders
+    cluster_sorties = getfield.(tenders, :sorties)
+
+    all_nodes::Set{Point{2, Float64}} = Set(vcat(getfield.(clusters, :nodes)...))
+    allocated_nodes::Set{Point{2, Float64}} = Set(
+        collect(Base.Iterators.flatten(
+            getfield.(Base.Iterators.flatten(cluster_sorties), :nodes))
+        )
+    )
+    unallocated_nodes = setdiff(all_nodes, allocated_nodes)
+
+    return unallocated_nodes
+end
+
+"""
     simulated_annealing(
         soln_init::MSTSolution,
         objective_function::Function,

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -123,10 +123,10 @@ function perturb_swap_solution(
     cluster_pair::Tuple{Int, Int},
     exclusions::DataFrame = DataFrame()
 )::MSTSolution
-    clust_a_idx, clust_b_idx = cluster_pair
-    tender_a = deepcopy(soln.tenders[clust_a_idx])
-    tender_b = deepcopy(soln.tenders[clust_b_idx])
-    sorties_a, sorties_b = tender_a.sorties, tender_b.sorties
+    clust_a_seq_idx, clust_b_seq_idx = cluster_pair
+
+    tender_a = soln.tenders[clust_a_seq_idx]
+    tender_b = soln.tenders[clust_b_seq_idx]
 
     # Pick random sorties and ensure both have nodes
     sortie_a_idx = rand(1:length(tender_a.sorties))
@@ -152,27 +152,26 @@ function perturb_swap_solution(
     updated_linestrings = getindex.(get_feasible_vector.(tours, Ref(exclusions)), 2)
     updated_tender_matrices = getindex.(get_feasible_matrix.(tours, Ref(exclusions)), 1)
 
-    sorties_a[sortie_a_idx] = Route(
+    sortie_a = Route(
         sortie_a.nodes,
         updated_tender_matrices[1],
         vcat(updated_linestrings[1]...)
     )
-
-    sorties_b[sortie_b_idx] = Route(
+    sortie_b = Route(
         sortie_b.nodes,
         updated_tender_matrices[2],
         vcat(updated_linestrings[2]...)
     )
 
     tenders_all::Vector{TenderSolution} = copy(soln.tenders)
-    tenders_all[clust_a_idx] = TenderSolution(
+    tenders_all[clust_a_seq_idx] = TenderSolution(
         tender_a.id,
         tender_a.start,
         tender_a.finish,
         sorties_a,
         tender_a.dist_matrix
     )
-    tenders_all[clust_b_idx] = TenderSolution(
+    tenders_all[clust_b_seq_idx] = TenderSolution(
         tender_b.id,
         tender_b.start,
         tender_b.finish,

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -150,16 +150,16 @@ function perturb_swap_solution(
         [[tender_b.start]; sortie_b.nodes; [tender_b.finish]]
     ]
     updated_linestrings = getindex.(get_feasible_vector.(tours, Ref(exclusions)), 2)
-    updated_tender_matrices = getindex.(get_feasible_matrix.(tours, Ref(exclusions)), 1)
+    updated_sortie_matrices = getindex.(get_feasible_matrix.(tours, Ref(exclusions)), 1)
 
     sortie_a = Route(
         sortie_a.nodes,
-        updated_tender_matrices[1],
+        updated_sortie_matrices[1],
         vcat(updated_linestrings[1]...)
     )
     sortie_b = Route(
         sortie_b.nodes,
-        updated_tender_matrices[2],
+        updated_sortie_matrices[2],
         vcat(updated_linestrings[2]...)
     )
 

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -136,25 +136,19 @@ function perturb_swap_solution(
         return soln
     end
 
+    # Swap two random nodes across the two sorties
     node_a_idx, node_b_idx = rand(1:length(sortie_a.nodes)), rand(1:length(sortie_b.nodes))
-
-    # Swap the nodes
     node_a, node_b = sortie_a.nodes[node_a_idx], sortie_b.nodes[node_b_idx]
     sortie_a.nodes[node_a_idx] = node_b
     sortie_b.nodes[node_b_idx] = node_a
 
-    # Recompute updated geometry and distances
-    tours_a = [[tender_a.start]; sortie_a.nodes; [tender_a.finish]]
-    tours_b = [[tender_b.start]; sortie_b.nodes; [tender_b.finish]]
-
-    updated_linestrings::Vector{Vector{Vector{LineString{2, Float64}}}} = getindex.(
-        get_feasible_vector.([tours_a, tours_b], Ref(exclusions)), 2
-    )
-
-    updated_tender_matrices::Vector{Matrix{Float64}} = getindex.(get_feasible_matrix.(
-        [tours_a, tours_b],
-        Ref(exclusions)
-    ), 1)
+    # Update routes for modified sorties
+    tours = [
+        [[tender_a.start]; sortie_a.nodes; [tender_a.finish]],
+        [[tender_b.start]; sortie_b.nodes; [tender_b.finish]]
+    ]
+    updated_linestrings = getindex.(get_feasible_vector.(tours, Ref(exclusions)), 2)
+    updated_tender_matrices = getindex.(get_feasible_matrix.(tours, Ref(exclusions)), 1)
 
     sorties_a[sortie_a_idx] = Route(
         sortie_a.nodes,

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -214,7 +214,14 @@ function perturb_swap_solution(
         tender_b.dist_matrix
     )
 
-    return MSTSolution(soln.cluster_sets, soln.mothership_routes, tenders_all)
+    # Create new perturbed solution
+    soln_perturbed = MSTSolution(
+        [new_clusters],
+        [soln.mothership_routes[end]],
+        tenders_all
+    )
+
+    return soln_perturbed
 end
 
 """

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -235,7 +235,18 @@ function simulated_annealing(
             "Iteration \tBest Value \t\tTemp\n\t0\t\t$obj_best\t$temp"
 
         for iteration in 1:max_iterations
-            soln_proposed = perturb_function(soln_current, clust_idx, exclusions)
+            if rand() < 0.5
+                # swap two nodes within the same cluster
+                soln_proposed = perturb_function(soln_current, clust_idx, exclusions)
+            else
+                # swap two nodes between two different random clusters
+                clust_swap_idx = shuffle(setdiff(1:length(cluster_set), clust_idx))[1]
+                soln_proposed = perturb_function(
+                    soln_current,
+                    (clust_idx, clust_swap_idx),
+                    exclusions
+                )
+            end
             obj_proposed = objective_function(soln_proposed)
             improvement = obj_current - obj_proposed
             static_ctr += 1

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -163,6 +163,16 @@ function perturb_swap_solution(
         vcat(updated_linestrings[2]...)
     )
 
+    # Re-compute sorties for the modified clusters
+    sorties_a = [
+        i == sortie_a_idx ? sortie_a : tender_a.sorties[i]
+        for i in 1:length(tender_a.sorties)
+    ]
+    sorties_b = [
+        i == sortie_b_idx ? sortie_b : tender_b.sorties[i]
+        for i in 1:length(tender_b.sorties)
+    ]
+
     tenders_all::Vector{TenderSolution} = copy(soln.tenders)
     tenders_all[clust_a_seq_idx] = TenderSolution(
         tender_a.id,

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -187,7 +187,8 @@ end
         opt_function::Function,
         objective_function::Function,
         perturb_function::Function,
-        exclusions::DataFrame = DataFrame();
+        exclusions_mothership::DataFrame = DataFrame(),
+        exclusions_tender::DataFrame = DataFrame();
         max_iterations::Int = 5_000,
         temp_init::Float64 = 500.0,
         cooling_rate::Float64 = 0.95,
@@ -202,7 +203,8 @@ function `objective_function` and the perturbation function `perturb_function`.
 - `opt_function`: Optimization function to use
 - `objective_function`: Objective function to use
 - `perturb_function`: Perturbation function to use
-- `exclusions`: Exclusions DataFrame
+- `exclusions_mothership`: DataFrame of exclusion polygons for the mothership
+- `exclusions_tender`: DataFrame of exclusion polygons for the tenders
 - `max_iterations`: Maximum number of iterations
 - `temp_init`: Initial temperature for simulated annealing
 - `cooling_rate`: Cooling rate for simulated annealing
@@ -217,7 +219,8 @@ function improve_solution(
     opt_function::Function,
     objective_function::Function,
     perturb_function::Function,
-    exclusions::DataFrame = DataFrame();
+    exclusions_mothership::DataFrame = DataFrame(),
+    exclusions_tender::DataFrame = DataFrame();
     max_iterations::Int = 5_000,
     temp_init::Float64 = 500.0,
     cooling_rate::Float64 = 0.95,
@@ -227,7 +230,8 @@ function improve_solution(
         soln,
         objective_function,
         perturb_function,
-        exclusions,
+        exclusions_mothership,
+        exclusions_tender,
         max_iterations,
         temp_init,
         cooling_rate,


### PR DESCRIPTION
Refactors solution perturbation logic to improve optimization:
- Implements a boolean flag to consider inclusoin of cross-cluster swaps.
  - If flag = true: Implements sub-cluster and cross-cluster node swaps with a 50/50 probability to diversify search.
- Introduces separate exclusion DataFrames for mothership and tenders for mothership route update during perturbation.
- Adds functionality to insert unallocated nodes into existing clusters and sorties to improve initial solutions.