### PR TITLE
Improves clustering with capacity constraints

### DIFF
--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -283,20 +283,13 @@ function capacitated_kmeans(
         return R * c
     end
 
-    function calc_centroid(cluster_indices)
-        return (
-            mean(coordinates_array[1, cluster_indices]),
-            mean(coordinates_array[2, cluster_indices])
-        )
-    end
-
     function single_run()
         clustering = kmeans(coordinates_array, k[]; maxiter=max_iter)
         clustering_assignment = copy(clustering.assignments)
 
         # build clusters & centroids
         clusters = findall.(.==(1:k[]), Ref(clustering_assignment))
-        centroids = calc_centroid.(clusters)
+        centroids = Tuple(Tuple(mean(coordinates_array[1:2,c]; dims=2)) for c in clusters)
 
         # enforce max cluster size
         # for each over-capacity cluster, reassign its furthest points
@@ -340,7 +333,10 @@ function capacitated_kmeans(
         clustering_assignment = single_run()
         k[] = maximum(clustering_assignment) <= max_k ? maximum(clustering_assignment) : max_k
         clusters = findall.(.==(1:k[]), Ref(clustering_assignment))
-        centroids = calc_centroid.(clusters)
+        centroids = Tuple(
+            Tuple(mean(coordinates_array[1:2,c]; dims=2))
+            for c in clusters
+        )
         cluster_score = sum(
             [sum(quick_distance.(clusters[i], Ref(centroids[i]))) for i in 1:k[]]
         )

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -241,7 +241,7 @@ end
         max_k::Int = 6,
         max_iter::Int = 1000,
         n_restarts::Int = 5
-    )
+    )::Vector{Int64}
 
 Cluster locations, ensuring that no cluster has more than `max_reef_number`, and all points
 are assigned to a cluster.
@@ -263,7 +263,7 @@ function capacitated_kmeans(
     max_k::Int = 6,
     max_iter::Int = 1000,
     n_restarts::Int = 5,
-)
+)::Vector{Int64}
     n_reefs = length(reef_data.LAT)
     k = Ref(ceil(Int, n_reefs/max_reef_number))
     coordinates_array = hcat(reef_data.LON, reef_data.LAT)' # 2×n for kmeans

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -230,11 +230,11 @@ end
 """
     capacitated_kmeans(
         coordinates_array::Matrix{Float64};
-        max_cluster_size::Int,
+        max_cluster_size::Int64,
         max_split_distance::Int64 = 12000,
-        max_k::Int = 6,
-        max_iter::Int = 1000,
-        n_restarts::Int = 20
+        max_k::Int64 = 6,
+        max_iter::Int64 = 1000,
+        n_restarts::Int64 = 20
     )::Vector{Int64}
 
 Cluster locations, ensuring that no cluster has more than `max_cluster_size`, and all points
@@ -253,18 +253,18 @@ A vector of cluster assignments for each reef.
 """
 function capacitated_kmeans(
     coordinates_array::Matrix{Float64};
-    max_cluster_size::Int,
+    max_cluster_size::Int64,
     max_split_distance::Int64 = 12000,
-    max_k::Int = 6,
-    max_iter::Int = 1000,
-    n_restarts::Int = 20,
+    max_k::Int64 = 6,
+    max_iter::Int64 = 1000,
+    n_restarts::Int64 = 20,
 )::Vector{Int64}
-    n_reefs = size(coordinates_array, 2)
+    n_reefs::Int64 = size(coordinates_array, 2)
     k = Ref(ceil(Int, n_reefs/max_cluster_size))
 
     # Run k-means multiple times to find best result
-    best_clustering_assignment = zeros(Int, n_reefs)
-    best_score = Inf
+    best_clustering_assignment::Vector{Int} = zeros(Int, n_reefs)
+    best_score::Float64 = Inf
     for _ in 1:n_restarts
         # Reset k every time
         clustering_assignment::Vector{Int64} = _constrained_kmeans_single_iteration(
@@ -275,12 +275,14 @@ function capacitated_kmeans(
             max_iter
         )
         k[] = maximum(clustering_assignment) <= max_k ? maximum(clustering_assignment) : max_k
-        clusters_list = findall.(.==(1:k[]), Ref(clustering_assignment))
+        clusters_list::Vector{Vector{Int64}} = findall.(
+            .==(1:k[]), Ref(clustering_assignment)
+        )
         centroids = Tuple(
             Tuple(mean(coordinates_array[1:2,c]; dims=2))
             for c in clusters_list
         )
-        cluster_score = sum(
+        cluster_score::Float64 = sum(
             haversine(coordinates_array[1:2, p], centroids[i])
             for i in 1:k[] for p in clusters_list[i]
         )

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -304,13 +304,7 @@ function capacitated_kmeans(
         for _ in 1:max_iter
             # build clusters & centroids
             clusters = findall.(.==(1:k), Ref(clustering_assignment))
-
-            empty_mask = isempty.(clusters)
-            means_lon = clustering.centers[1,:]
-            means_lat = clustering.centers[2,:]
-
-            cent_lon = ifelse.(empty_mask, means_lon, means_lon)
-            cent_lat = ifelse.(empty_mask, means_lat, means_lat)
+            centroids = calc_centroid.(clusters)
 
             updated = false
             # enforce max cluster size
@@ -319,7 +313,7 @@ function capacitated_kmeans(
                 point_idxs = clusters[c]
                 while length(point_idxs) > max_reef_number
                     # find furthest point from centroid
-                    dists = quick_distance.(point_idxs, Ref((cent_lon[c], cent_lat[c])))
+                    dists = quick_distance.(point_idxs, Ref((centroids[c])))
                     idx = point_idxs[argmax(dists)]
 
                     # find all clusters with available capacity
@@ -329,10 +323,7 @@ function capacitated_kmeans(
                     end
 
                     # find closest available cluster
-                    eligible_centroids = zip(
-                        cent_lon[available_clusters],
-                        cent_lat[available_clusters]
-                    )
+                    eligible_centroids = centroids[available_clusters]
                     eligible_distances = quick_distance.(Ref(idx), eligible_centroids)
                     closest_cluster = available_clusters[argmin(eligible_distances)]
 

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -65,6 +65,7 @@ function cluster_problem(
     points::Vector{Point{2, Float64}} = problem.targets.points.geometry
     current_location::Point{2, Float64} = problem.depot
     exclusions::DataFrame = problem.tenders.exclusion
+    total_tender_capacity::Int = problem.tenders.capacity * problem.tenders.number
 
     dist_vector = dist_weighting .* get_feasible_distances(
         current_location,
@@ -83,9 +84,7 @@ function cluster_problem(
 
     clustering_assignments = capacitated_kmeans(
         coordinates_array;
-        max_reef_number = 6,
-        max_iter = 1000,
-        n_restarts = 50,
+        max_cluster_size=total_tender_capacity,
     )
 
     clustered_targets_df::DataFrame = DataFrame(

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -235,7 +235,7 @@ end
         max_split_distance::Float64 = 12.0,
         max_k::Int = 6,
         max_iter::Int = 1000,
-        n_restarts::Int = 5
+        n_restarts::Int = 20
     )::Vector{Int64}
 
 Cluster locations, ensuring that no cluster has more than `max_cluster_size`, and all points
@@ -258,7 +258,7 @@ function capacitated_kmeans(
     max_split_distance::Float64 = 12.0,
     max_k::Int = 6,
     max_iter::Int = 1000,
-    n_restarts::Int = 5,
+    n_restarts::Int = 20,
 )::Vector{Int64}
     n_reefs = size(coordinates_array, 2)
     k = Ref(ceil(Int, n_reefs/max_cluster_size))

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -241,10 +241,11 @@ Cluster locations, ensuring that no cluster has more than `max_cluster_size`, an
 are assigned to a cluster.
 
 # Arguments
-- `coordinates`: A matrix of coordinates where each column represents a reef's
-    longitude and latitude (and optionally a third dimension for distance).
+- `coordinates`: A matrix of coordinates where each column represents a reef location, and
+    each row is a coordinate, i.e. longitude, latitude, (optionally distance).
 - `max_cluster_size`: The maximum number of reefs per cluster.
 - `max_split_distance`: The maximum distance (m) between clusters to allow for splitting.
+- `max_k`: The maximum number of clusters to create.
 - `max_iter`: The maximum number of iterations to run the k-means algorithm.
 - `n_restarts`: The number of times to run k-means with different initial centroids.
 

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -288,13 +288,10 @@ function capacitated_kmeans(
     end
 
     function calc_centroid(cluster_indices)
-        lon_sum = 0.0
-        lat_sum = 0.0
-        for i in cluster_indices
-            lon_sum += coordinates_array[1,i]
-            lat_sum += coordinates_array[2,i]
-        end
-        return (lon_sum / length(cluster_indices), lat_sum / length(cluster_indices))
+        return (
+            mean(coordinates_array[1, cluster_indices]),
+            mean(coordinates_array[2, cluster_indices])
+        )
     end
 
     function single_run()

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -237,7 +237,7 @@ end
     capacitated_kmeans(
         reef_data;
         max_reef_number::Int = 6,
-        max_iter::Int = 10,
+        max_iter::Int = 1000,
         n_restarts::Int = 5
     )
 
@@ -256,7 +256,7 @@ A vector of cluster assignments for each reef.
 function capacitated_kmeans(
     reef_data;
     max_reef_number::Int = 6,
-    max_iter::Int = 10,
+    max_iter::Int = 1000,
     n_restarts::Int = 5,
 )
     n_reefs = length(reef_data.LAT)
@@ -298,7 +298,7 @@ function capacitated_kmeans(
     end
 
     function single_run()
-        clustering = kmeans(coordinates_array, k)
+        clustering = kmeans(coordinates_array, k; maxiter=max_iter)
         clustering_assignment = copy(clustering.assignments)
 
         for _ in 1:max_iter

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -320,10 +320,10 @@ function capacitated_kmeans(
         # Reset k every time
         clustering_assignment = single_run()
         k[] = maximum(clustering_assignment) <= max_k ? maximum(clustering_assignment) : max_k
-        clusters = findall.(.==(1:k[]), Ref(clustering_assignment))
+        clusters_list = findall.(.==(1:k[]), Ref(clustering_assignment))
         centroids = Tuple(
             Tuple(mean(coordinates_array[1:2,c]; dims=2))
-            for c in clusters
+            for c in clusters_list
         )
         cluster_score = sum(
             haversine(coordinates_array[1:2, p], centroids[i])

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -238,6 +238,7 @@ end
         reef_data;
         max_reef_number::Int = 6,
         max_split_distance::Float64 = 12.0,
+        max_k::Int = 6,
         max_iter::Int = 1000,
         n_restarts::Int = 5
     )
@@ -259,6 +260,7 @@ function capacitated_kmeans(
     reef_data;
     max_reef_number::Int = 6,
     max_split_distance::Float64 = 12.0,
+    max_k::Int = 6,
     max_iter::Int = 1000,
     n_restarts::Int = 5,
 )
@@ -358,7 +360,7 @@ function capacitated_kmeans(
     for _ in 1:n_restarts
         # Reset k every time
         clustering_assignment = single_run()
-        k[] = maximum(clustering_assignment)
+        k[] = maximum(clustering_assignment) <= max_k ? maximum(clustering_assignment) : max_k
         clusters = findall.(.==(1:k[]), Ref(clustering_assignment))
         centroids = calc_centroid.(clusters)
         cluster_score = sum(

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -33,8 +33,6 @@ function initial_solution(
     # Load problem data
     clusters::Vector{Cluster} = cluster_problem(
         problem,
-        num_clusters,
-        cluster_tolerance,
     );
     cluster_centroids_df::DataFrame = generate_cluster_df(clusters, problem.depot)
 


### PR DESCRIPTION
Enhances clustering algorithm by introducing `capacitated_kmeans()` to adhere to capacity constraints by:
- clustering locations while ensuring no cluster exceeds a maximum size.
- splitting (creating an extra) clusters when distance to another available cluster is too large.
- Removes unnecessary parameters from `cluster_problem()`
  - `num_clusters`: not relevant when clusters are capacity-constrained as over-capacity clusters are split.
  - `cluster_tolerance`: un-used