### PR TITLE
Remove hardcoded RNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Optional parameters are:
 ```julia
 # Generate an initial solution
 solution_init = initial_solution(
-    problem,                                                        # problem
+    problem                                                        # problem
 );
 ```
 #### Solution parameters

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -11,9 +11,6 @@ using Hungarian
     # waypoints::NTuple{2, Point{2, Float64}}
 end
 
-Q = 1234
-GLOBAL_RNG = MersenneTwister(Q)
-
 """
     generate_cluster_df(
         clusters::Vector{Cluster},
@@ -180,8 +177,7 @@ function disturb_remaining_clusters(
     disturbance_clusters = kmeans(
         coordinates_array_3d,
         k_d;
-        tol=tol,
-        rng=GLOBAL_RNG
+        tol=tol
     )
 
     # Create a score based on the disturbance values for each cluster
@@ -237,8 +233,7 @@ function disturb_remaining_clusters(
     clustering = kmeans(
         coordinates_array_3d_disturbed,
         k;
-        tol=tol,
-        rng=GLOBAL_RNG
+        tol=tol
     )
 
     clustered_targets = similar(raster, Int64, missingval=0)
@@ -272,13 +267,12 @@ function disturb_remaining_clusters(
     # Create k_d clusters to create disturbance on subset
     k_d_lower = k + 1
     k_d_upper = n_sites
-    k_d = rand(GLOBAL_RNG, k_d_lower:k_d_upper)
+    k_d = rand(k_d_lower:k_d_upper)
 
     disturbance_clusters = kmeans(
         coordinates_3d,
         k_d;
-        tol=tol,
-        rng=GLOBAL_RNG
+        tol=tol
     )
 
     # Create a score based on the disturbance values for each cluster
@@ -292,7 +286,7 @@ function disturb_remaining_clusters(
             mean(coordinates_3d[3, disturbance_clusters.assignments.==i])
             for i in 1:k_d
         ] .+
-        t * rand(GLOBAL_RNG, -1.0:0.01:1.0, k_d)
+        t * rand(-1.0:0.01:1.0, k_d)
 
     # Assign the disturbance value to every node in the cluster
     disturbance_scores .= cluster_disturbance_vals[disturbance_clusters.assignments]
@@ -464,7 +458,7 @@ function _constrained_kmeans_single_iteration(
     k_spec::Int=0,
     tol::Float64=0.01
 )::Vector{Int64}
-    clustering = kmeans(coordinates, k; tol=tol, maxiter=max_iter, rng=GLOBAL_RNG)
+    clustering = kmeans(coordinates, k; tol=tol, maxiter=max_iter)
     clustering_assignment::Vector{Int64} = copy(clustering.assignments)
 
     # Build clusters & centroids

--- a/src/optimization/solution_assessment.jl
+++ b/src/optimization/solution_assessment.jl
@@ -36,7 +36,7 @@ function perturb_swap_solution(
     enforce_diff_sortie::Bool=false
 )::MSTSolution
     clust_seq_idx = clust_seq_idx_target == -1 ?
-                    rand(GLOBAL_RNG, 1:length(soln.tenders[end])) :
+                    rand(1:length(soln.tenders[end])) :
                     clust_seq_idx_target
 
     tender = deepcopy(soln.tenders[end][clust_seq_idx])
@@ -50,8 +50,8 @@ function perturb_swap_solution(
     # Choose two random sorties to swap nodes between
     # if enforce_diff_sortie is true: ensure different sorties are selected
     sortie_a_idx, sortie_b_idx = enforce_diff_sortie ?
-                                 shuffle(GLOBAL_RNG, 1:length(sorties))[1:2] :
-                                 rand(GLOBAL_RNG, 1:length(sorties), 2)
+                                 shuffle(1:length(sorties))[1:2] :
+                                 rand(1:length(sorties), 2)
 
     sortie_a, sortie_b = sorties[sortie_a_idx], sorties[sortie_b_idx]
 
@@ -67,11 +67,11 @@ function perturb_swap_solution(
         if sortie_length < 2
             return soln
         end
-        node_a_idx, node_b_idx = sortie_length == 2 ? (1, 2) : shuffle(GLOBAL_RNG, 1:sortie_length)[1:2]
+        node_a_idx, node_b_idx = sortie_length == 2 ? (1, 2) : shuffle(1:sortie_length)[1:2]
     else
         # Chose two random node indices from different sorties
-        node_a_idx = rand(GLOBAL_RNG, 1:length(sortie_a.nodes))
-        node_b_idx = rand(GLOBAL_RNG, 1:length(sortie_b.nodes))
+        node_a_idx = rand(1:length(sortie_a.nodes))
+        node_b_idx = rand(1:length(sortie_b.nodes))
     end
 
     # Swap the nodes between the two sorties
@@ -143,8 +143,8 @@ function perturb_swap_solution(
     tender_b = soln.tenders[end][clust_b_seq_idx]
 
     # Pick random sorties and ensure both have nodes
-    sortie_a_idx = rand(GLOBAL_RNG, 1:length(tender_a.sorties))
-    sortie_b_idx = rand(GLOBAL_RNG, 1:length(tender_b.sorties))
+    sortie_a_idx = rand(1:length(tender_a.sorties))
+    sortie_b_idx = rand(1:length(tender_b.sorties))
     sortie_a = deepcopy(tender_a.sorties[sortie_a_idx])
     sortie_b = deepcopy(tender_b.sorties[sortie_b_idx])
 
@@ -153,7 +153,7 @@ function perturb_swap_solution(
     end
 
     # Swap two random nodes across the two sorties
-    node_a_idx, node_b_idx = rand(GLOBAL_RNG, 1:length(sortie_a.nodes)), rand(GLOBAL_RNG, 1:length(sortie_b.nodes))
+    node_a_idx, node_b_idx = rand(1:length(sortie_a.nodes)), rand(1:length(sortie_b.nodes))
     node_a, node_b = sortie_a.nodes[node_a_idx], sortie_b.nodes[node_b_idx]
     sortie_a.nodes[node_a_idx] = node_b
     sortie_b.nodes[node_b_idx] = node_a
@@ -659,12 +659,12 @@ function simulated_annealing(
             if !cross_cluster_flag
                 soln_proposed = perturb_function(soln_current, clust_idx, exclusions_tender)
             else
-                if rand(GLOBAL_RNG) < 0.5
+                if rand() < 0.5
                     # swap two nodes within the same cluster
                     soln_proposed = perturb_function(soln_current, clust_idx, exclusions_tender)
                 else
                     # swap two nodes between two different random clusters
-                    clust_swap_idx = shuffle(GLOBAL_RNG, setdiff(1:length(cluster_set), clust_idx))[1]
+                    clust_swap_idx = shuffle(setdiff(1:length(cluster_set), clust_idx))[1]
                     soln_proposed = perturb_function(
                         soln_current,
                         (clust_idx, clust_swap_idx),
@@ -678,7 +678,7 @@ function simulated_annealing(
             static_ctr += 1
 
             # If the new solution is improved OR meets acceptance prob criteria
-            if improvement > 0 || exp(improvement / temp) > rand(GLOBAL_RNG)
+            if improvement > 0 || exp(improvement / temp) > rand()
                 soln_current = soln_proposed
                 obj_current = obj_proposed
 

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -122,6 +122,8 @@ end
         problem::Problem;
         k::Int=1,
         disturbance_clusters::Set{Int64}=Set{Int64}()
+        seed::Union{Nothing,Int64}=nothing,
+        rng::AbstractRNG=Random.GLOBAL_RNG
     )::MSTSolution
 
 Generate a solution to the problem for:
@@ -139,9 +141,13 @@ Best total MSTSolution found
 function solve_problem(
     problem::Problem;
     k::Int=1,
-    disturbance_clusters::Set{Int64}=Set{Int64}()
+    disturbance_clusters::Set{Int64}=Set{Int64}(),
+    seed::Union{Nothing,Int64}=nothing,
+    rng::AbstractRNG=Random.GLOBAL_RNG
 )::MSTSolution
-    Random.seed!(GLOBAL_RNG, Q)
+    if !isnothing(seed)
+        Random.seed!(rng, seed)
+    end
 
     ordered_disturbances = sort(unique(disturbance_clusters))
     n_events = length(ordered_disturbances) + 1


### PR DESCRIPTION
The previous approach hardcoded an RNG (Random Number Generator) and seed value into the package module itself.

```julia
Q = 1234
GLOBAL_RNG = MersenneTwister(Q)
```

This would have the opposite effect of reproducibility as it ensures completely different results on each run.
It would also be confusing to the user who sets a value for `Random.seed!()` because the global RNG is not used at all - so results would appear to change even if a consistent/identical seed value is used on repeat runs.

```julia
# Example
using Random

Random.seed!(101)

problem = load_problem(
    "data/target_locations (scenarios)/output_slopes_3-10m.geojson",           # target_path
    "data/target_cluster (site)/Moore_2024-02-14b_v060_rc1.gpkg",               # subset_path
    "data/env_constraints/Cairns-Cooktown_bathy.tif",                                    # bathy_path
    "data/env_disturbances/output_slope_zs_Hs_Tp.geojson",                         # wave_disturbance_path
    (146.175, -16.84),                             # depot
    -10.0,                                                # draft_ms
    -5.0,                                                  # draft_t
    5.0,                                                   # weight_ms
    2.0,                                                   # weight_t
    3,                                                      # n_tenders
    2;                                                      # t_cap
);

# Generate an initial solution
sol1= initial_solution(problem);

# Re-generate initial solution with same random seed
Random.seed!(101)
sol2 = initial_solution(problem);

# The results above (sol1 and sol2) should be identical but will likely be different despite resetting the random seed.
```

This PR is subject to confirmation due to unrelated bugs (in the plotting methods) it is difficult to confirm identical results are obtained (visually) when re-running the example above.

There is a tentative interface for `solve_problem()` which accepts a user-set RNG and/or seed value but this needs to propagate through all methods that uses the RNG. The above approach simpler but may not be safe for multi-threaded/parallel use.