### PR TITLE
Fixes `apply_improved()`

### DIFF
--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -195,7 +195,7 @@ function solve(
     )
 
     # Apply the optimized initial solution to the first set of clusters pre-disturbance
-    cluster_sets[1], ms_soln_sets[1], tender_soln_sets[1] = apply_improved!(
+    cluster_sets[1], ms_soln_sets[1], tender_soln_sets[1] = apply_improved(
         optimized_initial,
         clusters,
         initial_tenders,
@@ -280,7 +280,7 @@ function solve(
         # Update with improved solution to the current cluster set and tender solutions
         cluster_sets[disturbance_cluster_idx],
         ms_soln_sets[disturbance_cluster_idx],
-        tender_soln_sets[disturbance_cluster_idx] = apply_improved!(
+        tender_soln_sets[disturbance_cluster_idx] = apply_improved(
             optimized_current_solution,
             clusters,
             current_tender_soln

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -320,7 +320,7 @@ function apply_improved!(
     #Overwrite updated tenders
     updated_tenders = soln.tenders[1]
     tender_ids = getfield.(updated_tenders, :id)
-    Main.@infiltrate
+
     tender_idxs = findfirst.(.==(tender_ids), Ref(getfield.(existing_tenders, :id)))
     existing_tenders[tender_idxs] .= updated_tenders
 

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -196,10 +196,9 @@ function solve(
 
     # Apply the optimized initial solution to the first set of clusters pre-disturbance
     cluster_sets[1], ms_soln_sets[1], tender_soln_sets[1] = apply_improved!(
-        clusters,
-        tender_soln_sets,
         optimized_initial,
-        1
+        clusters,
+        initial_tenders,
     )
 
     # Iterate through each disturbance event and update solution
@@ -282,7 +281,9 @@ function solve(
         cluster_sets[disturbance_cluster_idx],
         ms_soln_sets[disturbance_cluster_idx],
         tender_soln_sets[disturbance_cluster_idx] = apply_improved!(
-            clusters, tender_soln_sets, optimized_current_solution, d_idx
+            optimized_current_solution,
+            clusters,
+            current_tender_soln
         )
     end
 

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -291,7 +291,7 @@ function solve(
 end
 
 """
-    apply_improved!(
+    apply_improved(
         improved_soln::MSTSolution,
         existing_clusters::Vector{Cluster},
         existing_tenders::Vector{TenderSolution},
@@ -307,30 +307,29 @@ Update the clusters and tenders with the improved solution.
 # Returns
 - A tuple containing the updated clusters, the mothership route, and the updated tenders for the specified event index.
 """
-function apply_improved!(
+function apply_improved(
     improved_soln::MSTSolution,
     existing_clusters::Vector{Cluster},
     existing_tenders::Vector{TenderSolution},
 )
-    # Overwrite updated clusters
-    updated_clusters = improved_soln.cluster_sets[1]
-    ids = getfield.(updated_clusters, :id)
-    existing_clusters[ids] .= updated_clusters
+    # Update clusters
+    improved_clusters = improved_soln.cluster_sets[1]
+    ids = getfield.(improved_clusters, :id)
+    updated_clusters::Vector{Cluster} = deepcopy(existing_clusters)
+    updated_clusters[ids] .= improved_clusters
 
-    #Overwrite updated tenders
-    updated_tenders = improved_soln.tenders[1]
-    tender_ids = getfield.(updated_tenders, :id)
+    # Update tenders
+    improved_tenders = improved_soln.tenders[1]
+    tender_ids = getfield.(improved_tenders, :id)
 
     tender_idxs = findfirst.(.==(tender_ids), Ref(getfield.(existing_tenders, :id)))
-    existing_tenders[tender_idxs] .= updated_tenders
+    updated_tender_soln::Vector{TenderSolution} = deepcopy(existing_tenders)
+    updated_tender_soln[tender_idxs] .= improved_tenders
 
-    # Record the updated clusters and tenders for the current index
     return (
-      deepcopy(existing_clusters),
-      improved_soln.mothership_routes[1],
-      existing_tenders
-    )
-end
+      updated_clusters,
+      deepcopy(improved_soln.mothership_routes[1]),
+      updated_tender_soln
     )
 end
 

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -291,28 +291,25 @@ end
 
 """
     apply_improved!(
-        clusters::Vector{Cluster},
-        tenders::Vector{Vector{TenderSolution}},
         soln::MSTSolution,
-        event_idx::Int
+        clusters::Vector{Cluster},
+        existing_tenders::Vector{TenderSolution},
     )::Tuple{Vector{Cluster}, MothershipSolution, Vector{TenderSolution}}
 
-Overwrite the clusters and tenders in the current solution with the updated ones from the improved solution.
+Update the clusters and tenders with the improved solution.
 
 # Arguments
-- `clusters`: Vector of clusters to update.
-- `tenders`: Vector of tender solutions for each event.
 - `soln`: The improved solution containing updated clusters and tenders.
-- `event_idx`: Index of the event for which the tenders are being updated.
+- `clusters`: Vector of clusters to update.
+- `existing_tenders`: Vector of tender solutions for each event.
 
 # Returns
 - A tuple containing the updated clusters, the mothership route, and the updated tenders for the specified event index.
 """
 function apply_improved!(
-    clusters::Vector{Cluster},
-    tenders::Vector{Vector{TenderSolution}},
     soln::MSTSolution,
-    event_idx::Int
+    clusters::Vector{Cluster},
+    existing_tenders::Vector{TenderSolution},
 )
     # Overwrite updated clusters
     updated_clusters = soln.cluster_sets[1]
@@ -323,14 +320,16 @@ function apply_improved!(
     updated_tenders = soln.tenders[1]
     tender_ids = getfield.(updated_tenders, :id)
     Main.@infiltrate
-    tender_idxs = findfirst.(.==(tender_ids), Ref(getfield.(tenders[event_idx], :id)))
-    tenders[event_idx][tender_idxs] .= updated_tenders
+    tender_idxs = findfirst.(.==(tender_ids), Ref(getfield.(existing_tenders, :id)))
+    existing_tenders[tender_idxs] .= updated_tenders
 
     # Record the updated clusters and tenders for the current index
     return (
       deepcopy(clusters),
       soln.mothership_routes[1],
-      tenders[event_idx]
+      existing_tenders
+    )
+end
     )
 end
 

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -292,33 +292,33 @@ end
 
 """
     apply_improved!(
-        soln::MSTSolution,
-        clusters::Vector{Cluster},
+        improved_soln::MSTSolution,
+        existing_clusters::Vector{Cluster},
         existing_tenders::Vector{TenderSolution},
     )::Tuple{Vector{Cluster}, MothershipSolution, Vector{TenderSolution}}
 
 Update the clusters and tenders with the improved solution.
 
 # Arguments
-- `soln`: The improved solution containing updated clusters and tenders.
-- `clusters`: Vector of clusters to update.
+- `improved_soln`: The improved solution containing updated clusters and tenders.
+- `existing_clusters`: Vector of clusters to update.
 - `existing_tenders`: Vector of tender solutions for each event.
 
 # Returns
 - A tuple containing the updated clusters, the mothership route, and the updated tenders for the specified event index.
 """
 function apply_improved!(
-    soln::MSTSolution,
-    clusters::Vector{Cluster},
+    improved_soln::MSTSolution,
+    existing_clusters::Vector{Cluster},
     existing_tenders::Vector{TenderSolution},
 )
     # Overwrite updated clusters
-    updated_clusters = soln.cluster_sets[1]
+    updated_clusters = improved_soln.cluster_sets[1]
     ids = getfield.(updated_clusters, :id)
-    clusters[ids] .= updated_clusters
+    existing_clusters[ids] .= updated_clusters
 
     #Overwrite updated tenders
-    updated_tenders = soln.tenders[1]
+    updated_tenders = improved_soln.tenders[1]
     tender_ids = getfield.(updated_tenders, :id)
 
     tender_idxs = findfirst.(.==(tender_ids), Ref(getfield.(existing_tenders, :id)))
@@ -326,8 +326,8 @@ function apply_improved!(
 
     # Record the updated clusters and tenders for the current index
     return (
-      deepcopy(clusters),
-      soln.mothership_routes[1],
+      deepcopy(existing_clusters),
+      improved_soln.mothership_routes[1],
       existing_tenders
     )
 end

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -305,7 +305,8 @@ Update the clusters and tenders with the improved solution.
 - `existing_tenders`: Vector of tender solutions for each event.
 
 # Returns
-- A tuple containing the updated clusters, the mothership route, and the updated tenders for the specified event index.
+- A tuple containing the updated clusters, the mothership route, and the updated tenders for
+the specified event index.
 """
 function apply_improved(
     improved_soln::MSTSolution,


### PR DESCRIPTION
Refactors the application of improved solutions to cluster sets and tender solutions.
- Removes `Main.@infiltrate` call
- Refactors `apply_improved()`
  - updates variable names for clarity
  - updates function signature to simplify and align with convention
  - returns updated variables to avoid mutating arguments.
- Implements updated `apply_improved()`