### PR TITLE
Fix tender route plotting

### DIFF
--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -344,11 +344,12 @@ function tenders!(
     ax::Axis,
     tender_soln::Vector{HierarchicalRouting.TenderSolution}
 )
+    # Create custom colormap, skipping the first two colors (yellow and black)
     colormap = distinguishable_colors(length(tender_soln) + 2)[3:end]
 
     # TODO: Plot critical path (longest) thicker than other paths
-    for t_soln in tender_soln
-        base_hue = convert_rgb_to_hue(colormap[t_soln.id])
+    for (t_n, t_soln) in enumerate(tender_soln)
+        base_hue = convert_rgb_to_hue(colormap[t_n])
         s = length(t_soln.sorties)
         palette = sequential_palette(base_hue, s+3)[3:end]
 

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -34,24 +34,24 @@ Create a plot of nodes by cluster.
 """
 function clusters(
     ;
-    clusters::Union{Vector{HierarchicalRouting.Cluster}, Nothing} = nothing,
-    cluster_sequence::Union{DataFrame, Nothing} = nothing,
-    cluster_radius::Real = 0,
-    nodes::Bool = true,
-    centers::Bool = false,
-    labels::Bool = false
+    clusters::Union{Vector{HierarchicalRouting.Cluster},Nothing}=nothing,
+    cluster_sequence::Union{DataFrame,Nothing}=nothing,
+    cluster_radius::Real=0,
+    nodes::Bool=true,
+    centers::Bool=false,
+    labels::Bool=false
 )
-    fig = Figure(size = (800, 600))
-    ax = Axis(fig[1, 1], xlabel = "Longitude", ylabel = "Latitude")
+    fig = Figure(size=(800, 600))
+    ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
 
     clusters!(
         ax,
-        clusters = clusters,
-        cluster_sequence = cluster_sequence,
-        cluster_radius = cluster_radius,
-        nodes = nodes,
-        centers = centers,
-        labels = labels
+        clusters=clusters,
+        cluster_sequence=cluster_sequence,
+        cluster_radius=cluster_radius,
+        nodes=nodes,
+        centers=centers,
+        labels=labels
     )
 
     return fig, ax
@@ -82,12 +82,12 @@ Plot nodes by cluster.
 """
 function clusters!(
     ax::Axis;
-    clusters::Union{Vector{HierarchicalRouting.Cluster}, Nothing} = nothing,
-    cluster_sequence::Union{DataFrame, Nothing} = nothing,
-    cluster_radius::Real = 0,
-    nodes::Bool = true,
-    centers::Bool = false,
-    labels::Bool = false
+    clusters::Union{Vector{HierarchicalRouting.Cluster},Nothing}=nothing,
+    cluster_sequence::Union{DataFrame,Nothing}=nothing,
+    cluster_radius::Real=0,
+    nodes::Bool=true,
+    centers::Bool=false,
+    labels::Bool=false
 )
     # Validate inputs
     if isnothing(clusters) && isnothing(cluster_sequence)
@@ -98,7 +98,7 @@ function clusters!(
     if !isnothing(cluster_sequence)
         sequence_id = [row.id for row in eachrow(cluster_sequence)[2:end-1]]
         colormap = distinguishable_colors(length(sequence_id) + 2)[3:end]
-        centroids = hcat(cluster_sequence.lon, cluster_sequence.lat)[2:end-1,:]
+        centroids = hcat(cluster_sequence.lon, cluster_sequence.lat)[2:end-1, :]
     elseif !isnothing(clusters)
         sequence_id = 1:length(clusters)
         colormap = distinguishable_colors(length(clusters) + 2)[3:end]
@@ -115,25 +115,25 @@ function clusters!(
 
         # plot nodes
         if nodes && !isnothing(clusters) && !isempty(clusters[seq].nodes)
-            scatter!(ax, clusters[seq].nodes, color = color, markersize = 10, marker = :x)
+            scatter!(ax, clusters[seq].nodes, color=color, markersize=10, marker=:x)
         end
 
         center_lon, center_lat = !isnothing(cluster_sequence) ?
-            centroids[idx, :] :
-            centroids[seq, :]
+                                 centroids[idx, :] :
+                                 centroids[seq, :]
 
         if cluster_radius > 0
             circle_lons = center_lon .+ circle_offsets[1]
             circle_lats = center_lat .+ circle_offsets[2]
 
-            poly!(ax, hcat(circle_lons, circle_lats), color = (color, 0.2), strokecolor = color, label = "Cluster Centroids")
+            poly!(ax, hcat(circle_lons, circle_lats), color=(color, 0.2), strokecolor=color, label="Cluster Centroids")
         end
 
         if centers
-            scatter!(ax, [center_lon], [center_lat], markersize = 10, color = (color, 0.2), strokewidth = 0)
+            scatter!(ax, [center_lon], [center_lat], markersize=10, color=(color, 0.2), strokewidth=0)
         end
         if labels
-            text!(ax, center_lon, center_lat, text = string(seq), align = (:center, :center), color = color)
+            text!(ax, center_lon, center_lat, text=string(seq), align=(:center, :center), color=color)
         end
     end
     return ax
@@ -156,12 +156,12 @@ Create a plot of exclusion zones.
 """
 function exclusions(
     exclusions::DataFrame;
-    labels::Bool = false
+    labels::Bool=false
 )
-    fig = Figure(size = (800, 600))
-    ax = Axis(fig[1, 1], xlabel = "Longitude", ylabel = "Latitude")
+    fig = Figure(size=(800, 600))
+    ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
 
-    exclusions!(ax, exclusions, labels = labels)
+    exclusions!(ax, exclusions, labels=labels)
 
     return fig, ax
 end
@@ -185,17 +185,17 @@ Plot exclusion zones.
 function exclusions!(
     ax::Axis,
     exclusions::DataFrame;
-    labels::Bool = false
+    labels::Bool=false
 )
     for (i, zone) in enumerate(eachrow(exclusions))
         polygon = zone[:geometry]
         for ring in GeoInterface.coordinates(polygon)
             xs, ys = [coord[1] for coord in ring], [coord[2] for coord in ring]
-            poly!(ax, xs, ys, color = (:gray, 0.5), strokecolor = :black)#, label = "Exclusion Zone")
+            poly!(ax, xs, ys, color=(:gray, 0.5), strokecolor=:black)#, label = "Exclusion Zone")
 
             if labels
                 centroid_x, centroid_y = mean(xs), mean(ys)
-                text!(ax, centroid_x, centroid_y, text = string(i), align = (:center, :center), color = :grey)
+                text!(ax, centroid_x, centroid_y, text=string(i), align=(:center, :center), color=:grey)
             end
         end
     end
@@ -223,14 +223,14 @@ Create a plot of LineStrings for mothership route.
 """
 function linestrings(
     route::HierarchicalRouting.Route;
-    markers::Bool = false,
-    labels::Bool = false,
-    color = nothing
+    markers::Bool=false,
+    labels::Bool=false,
+    color=nothing
 )
-    fig = Figure(size = (800, 600))
-    ax = Axis(fig[1, 1], xlabel = "Longitude", ylabel = "Latitude")
+    fig = Figure(size=(800, 600))
+    ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
 
-    linestrings!(ax, route, markers = markers, labels = labels, color = color)
+    linestrings!(ax, route, markers=markers, labels=labels, color=color)
 
     return fig, ax
 end
@@ -258,9 +258,9 @@ Plot LineStrings for mothership route.
 function linestrings!(
     ax::Axis,
     route::HierarchicalRouting.Route;
-    markers::Bool = false,
-    labels::Bool = false,
-    color = nothing
+    markers::Bool=false,
+    labels::Bool=false,
+    color=nothing
 )
     line_strings = route.line_strings
     waypoints = route.nodes[1:end-1]
@@ -273,7 +273,7 @@ function linestrings!(
 
     # Mark waypoints with 'x'
     if markers
-        scatter!(waypoint_matrix, marker = 'x', markersize = 10, color = :black)#, label = "Waypoints")
+        scatter!(waypoint_matrix, marker='x', markersize=10, color=:black)#, label = "Waypoints")
         # series(waypoint_matrix, marker = 'x', markersize = 10, color = :black, label = "Waypoints")
     end
 
@@ -286,12 +286,12 @@ function linestrings!(
                  [Point(p[1], p[2]) for p in line_string.points] :
                  [Point(p[1], p[2]) for l in line_string for p in l.points]
         line_width = line_color == :black ? 3 : 2
-        lines!(ax, points, color = line_color, linewidth = line_width)
+        lines!(ax, points, color=line_color, linewidth=line_width)
     end
 
     if labels
         # Annotate waypoints by sequence
-        text!(ax, waypoint_matrix[:,1], waypoint_matrix[:,2] .+ 0.002, text = string.(0:size(waypoint_matrix,1)-1), align = (:center, :center), color = :black)
+        text!(ax, waypoint_matrix[:, 1], waypoint_matrix[:, 2] .+ 0.002, text=string.(0:size(waypoint_matrix, 1)-1), align=(:center, :center), color=:black)
     end
     return ax
 end
@@ -312,8 +312,8 @@ Create a plot of tender routes within each cluster.
 function tenders(
     tender_soln::Vector{HierarchicalRouting.TenderSolution}
 )
-    fig = Figure(size = (800, 600))
-    ax = Axis(fig[1, 1], xlabel = "Longitude", ylabel = "Latitude")
+    fig = Figure(size=(800, 600))
+    ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
 
     tenders!(ax, tender_soln)
 
@@ -351,10 +351,10 @@ function tenders!(
     for (t_n, t_soln) in enumerate(tender_soln)
         base_hue = convert_rgb_to_hue(colormap[t_n])
         s = length(t_soln.sorties)
-        palette = sequential_palette(base_hue, s+3)[3:end]
+        palette = sequential_palette(base_hue, s + 3)[3:end]
 
         for (sortie, color) in zip(t_soln.sorties, palette[1:s])
-            linestrings!(ax, sortie, color = color)
+            linestrings!(ax, sortie, color=color)
         end
     end
     return ax
@@ -370,10 +370,10 @@ function tenders!(
     for t_soln in tender_soln
         base_hue = convert_rgb_to_hue(colormap[t_soln.id])
         s = length(t_soln.sorties)
-        palette = sequential_palette(base_hue, s+3)[3:end]
+        palette = sequential_palette(base_hue, s + 3)[3:end]
 
         for (sortie, color) in zip(t_soln.sorties, palette[1:s])
-            linestrings!(ax, sortie, color = color)
+            linestrings!(ax, sortie, color=color)
         end
     end
     return ax

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -12,22 +12,24 @@ using GLMakie, GeoMakie
 
 """
     clusters(
-        clusters::Union{Vector{HierarchicalRouting.Cluster}, Nothing} = nothing,
-        cluster_sequence::Union{DataFrame, Nothing} = nothing,
-        cluster_radius::Real = 0,
-        centers = false,
-        labels = false
-    )
+        ;
+        clusters::Union{Vector{HierarchicalRouting.Cluster},Nothing}=nothing,
+        cluster_sequence::Union{DataFrame,Nothing}=nothing,
+        cluster_radius::Real=0,
+        nodes::Bool=true,
+        centers::Bool=false,
+        labels::Bool=false
+    )::Tuple{Figure, Axis}
 
 Create a plot of nodes by cluster.
 
 # Arguments
-- `clusters::Union{Vector{HierarchicalRouting.Cluster}, Nothing}`: Clusters.
-- `cluster_sequence::Union{DataFrame, Nothing}`: Cluster by sequence visited.
-- `cluster_radius::Real`: Radius of circle to represent clusters.
-- `nodes::Bool`: Plot nodes flag.
-- `centers::Bool`: Plot cluster centers flag.
-- `labels::Bool`: Plot cluster labels flag.
+- `clusters`: Clusters to plot.
+- `cluster_sequence`: Cluster by sequence visited.
+- `cluster_radius`: Radius of circle to represent clusters.
+- `nodes`: Plot nodes flag.
+- `centers`: Plot cluster centers flag.
+- `labels`: Plot cluster labels flag.
 
 # Returns
 - `fig, ax`: Figure and Axis objects.
@@ -40,7 +42,7 @@ function clusters(
     nodes::Bool=true,
     centers::Bool=false,
     labels::Bool=false
-)
+)::Tuple{Figure, Axis}
     fig = Figure(size=(800, 600))
     ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
 
@@ -59,23 +61,24 @@ end
 """
     clusters!(
         ax::Axis;
-        clusters::Union{Vector{HierarchicalRouting.Cluster}, Nothing} = nothing,
-        cluster_sequence::Union{DataFrame, Nothing} = nothing,
-        cluster_radius::Real = 0,
-        nodes::Bool = true,
-        centers::Bool = false,
-        labels::Bool = false
-    )
+        clusters::Union{Vector{HierarchicalRouting.Cluster},Nothing}=nothing,
+        cluster_sequence::Union{DataFrame,Nothing}=nothing,
+        cluster_radius::Real=0,
+        nodes::Bool=true,
+        centers::Bool=false,
+        labels::Bool=false
+    )::Axis
 
 Plot nodes by cluster.
 
 # Arguments
-- `ax::Axis`: Axis object.
-- `clusters::Union{Vector{HierarchicalRouting.Cluster}, Nothing}`: Clusters.
-- `cluster_sequence::Union{DataFrame, Nothing}`: Cluster by sequence visited.
-- `cluster_radius::Real`: Radius of circle to represent clusters.
-- `centers::Bool`: Plot cluster centers flag.
-- `labels::Bool`: Plot cluster labels flag.
+- `ax`: Axis object.
+- `clusters`: Clusters to plot.
+- `cluster_sequence`: Cluster by sequence visited.
+- `cluster_radius`: Radius of circle to represent clusters.
+- `nodes`: Plot nodes flag.
+- `centers`: Plot cluster centers flag.
+- `labels`: Plot cluster labels flag.
 
 # Returns
 - `ax`: Axis object.
@@ -88,7 +91,7 @@ function clusters!(
     nodes::Bool=true,
     centers::Bool=false,
     labels::Bool=false
-)
+)::Axis
     # Validate inputs
     if isnothing(clusters) && isnothing(cluster_sequence)
         error("At least one of `clusters` or `cluster_sequence` must be provided.")
@@ -142,14 +145,14 @@ end
 """
     exclusions(
         exclusions::DataFrame;
-        labels::Bool = false
-    )
+        labels::Bool=false
+    )::Tuple{Figure, Axis}
 
 Create a plot of exclusion zones.
 
 # Arguments
-- `exclusions::DataFrame`: Exclusion zone polygons.
-- `labels::Bool`: Plot exclusion zones flag.
+- `exclusions`: Exclusion zone polygons.
+- `labels`: Plot exclusion zones flag.
 
 # Returns
 - `fig, ax`: Figure and Axis objects.
@@ -157,7 +160,7 @@ Create a plot of exclusion zones.
 function exclusions(
     exclusions::DataFrame;
     labels::Bool=false
-)
+)::Tuple{Figure, Axis}
     fig = Figure(size=(800, 600))
     ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
 
@@ -169,15 +172,15 @@ end
     exclusions!(
         ax::Axis,
         exclusions::DataFrame;
-        labels::Bool = false
-    )
+        labels::Bool=false
+    )::Axis
 
 Plot exclusion zones.
 
 # Arguments
-- `ax::Axis`: Axis object.
-- `exclusions::DataFrame`: Exclusion zone polygons.
-- `labels::Bool`: Plot exclusion zones flag.
+- `ax`: Axis object.
+- `exclusions`: Exclusion zone polygons.
+- `labels`: Plot exclusion zones flag.
 
 # Returns
 - `ax`: Axis object.
@@ -186,7 +189,7 @@ function exclusions!(
     ax::Axis,
     exclusions::DataFrame;
     labels::Bool=false
-)
+)::Axis
     for (i, zone) in enumerate(eachrow(exclusions))
         polygon = zone[:geometry]
         for ring in GeoInterface.coordinates(polygon)
@@ -205,17 +208,17 @@ end
 """
     linestrings(
         route::HierarchicalRouting.Route;
-        markers::Bool = false,
-        labels::Bool = false,
-        color = nothing
-    )
+        markers::Bool=false,
+        labels::Bool=false,
+        color=nothing
+    )::Tuple{Figure, Axis}
 
 Create a plot of LineStrings for mothership route.
 
 # Arguments
-- `route::HierarchicalRouting.Route`: Route including nodes and LineStrings.
-- `markers::Bool`: Plot waypoints flag.
-- `labels::Bool`: Plot LineString labels flag.
+- `route`: Route including nodes and LineStrings.
+- `markers`: Plot waypoints flag.
+- `labels`: Plot LineString labels flag.
 - `color`: LineString color.
 
 # Returns
@@ -226,7 +229,7 @@ function linestrings(
     markers::Bool=false,
     labels::Bool=false,
     color=nothing
-)
+)::Tuple{Figure, Axis}
     fig = Figure(size=(800, 600))
     ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
 
@@ -238,18 +241,18 @@ end
     linestrings!(
         ax::Axis,
         route::HierarchicalRouting.Route;
-        markers::Bool = false,
-        labels::Bool = false,
-        color = nothing
-    )
+        markers::Bool=false,
+        labels::Bool=false,
+        color=nothing
+    )::Axis
 
 Plot LineStrings for mothership route.
 
 # Arguments
-- `ax::Axis`: Axis object.
-- `route::HierarchicalRouting.Route`: Route including nodes and LineStrings.
-- `markers::Bool`: Plot waypoints flag.
-- `labels::Bool`: Plot LineString labels flag.
+- `ax`: Axis object.
+- `route`: Route including nodes and LineStrings.
+- `markers`: Plot waypoints flag.
+- `labels`: Plot LineString labels flag.
 - `color`: LineString color.
 
 # Returns
@@ -261,7 +264,7 @@ function linestrings!(
     markers::Bool=false,
     labels::Bool=false,
     color=nothing
-)
+)::Axis
     line_strings = route.line_strings
     waypoints = route.nodes[1:end-1]
 
@@ -299,7 +302,7 @@ end
 """
     tenders(
         tender_soln::Vector{HierarchicalRouting.TenderSolution}
-    )
+    )::Tuple{Figure, Axis}
 
 Create a plot of tender routes within each cluster.
 
@@ -311,7 +314,7 @@ Create a plot of tender routes within each cluster.
 """
 function tenders(
     tender_soln::Vector{HierarchicalRouting.TenderSolution}
-)
+)::Tuple{Figure, Axis}
     fig = Figure(size=(800, 600))
     ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
 
@@ -319,16 +322,17 @@ function tenders(
 
     return fig, ax
 end
+
 """
     tenders!(
         ax::Axis,
         tender_soln::Vector{HierarchicalRouting.TenderSolution}
-    )
+    )::Axis
     function tenders!(
         ax::Axis,
         tender_soln::Vector{HierarchicalRouting.TenderSolution},
         num_clusters::Int64
-    )
+    )::Axis
 
 Plot tender routes within each cluster, colored by cluster, sequentially shaded by sortie.
 
@@ -343,7 +347,7 @@ Plot tender routes within each cluster, colored by cluster, sequentially shaded 
 function tenders!(
     ax::Axis,
     tender_soln::Vector{HierarchicalRouting.TenderSolution}
-)
+)::Axis
     # Create custom colormap, skipping the first two colors (yellow and black)
     colormap = distinguishable_colors(length(tender_soln) + 2)[3:end]
 
@@ -363,7 +367,7 @@ function tenders!(
     ax::Axis,
     tender_soln::Vector{HierarchicalRouting.TenderSolution},
     num_clusters::Int64
-)
+)::Axis
     colormap = distinguishable_colors(num_clusters + 2)[3:end]
 
     # TODO: Plot critical path (longest) thicker than other paths


### PR DESCRIPTION
Closes #72 

Handles potential mismatch between length of tender ids and their actual id values.

e.g., there may be 5 tenders but their ids may be 1, 2, 100, 3, 8.

I suspect, however, that there is a deeper issue if tender IDs are being dropped?