### PR TITLE
Letter IDs for clusters to avoid confusion

### DIFF
--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -1,10 +1,10 @@
 
-using Clustering
 using Random
 using Hungarian
+using Clustering
 
 @kwdef struct Cluster
-    id::Int
+    id::Int64
     centroid::Point{2,Float64}
     nodes::Vector{Point{2,Float64}} = [centroid]
     # TODO: Add waypoints?

--- a/src/clustering/clustering.jl
+++ b/src/clustering/clustering.jl
@@ -11,6 +11,30 @@ using Clustering
     # waypoints::NTuple{2, Point{2, Float64}}
 end
 
+function generate_letter_id(idx::Int64)
+    idx < 0 && throw(ArgumentError("Index must be non-negative"))
+
+    result = ""
+    n = idx
+
+    while true
+        result = string(Char('A' + (n % 26))) * result
+        n = n ÷ 26
+        if n == 0
+            break
+        end
+        n -= 1  # Key adjustment for letter-based numbering
+    end
+
+    return result
+end
+function generate_letter_id(c::Cluster)
+    return generate_letter_id(c.id)
+end
+function generate_letter_id(t::TenderSolution)
+    return generate_letter_id(t.id)
+end
+
 """
     generate_cluster_df(
         clusters::Vector{Cluster},

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -42,7 +42,7 @@ function clusters(
     nodes::Bool=true,
     centers::Bool=false,
     labels::Bool=false
-)::Tuple{Figure, Axis}
+)::Tuple{Figure,Axis}
     fig = Figure(size=(800, 600))
     ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
 
@@ -161,7 +161,7 @@ Create a plot of exclusion zones.
 function exclusions(
     exclusions::DataFrame;
     labels::Bool=false
-)::Tuple{Figure, Axis}
+)::Tuple{Figure,Axis}
     fig = Figure(size=(800, 600))
     ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
 
@@ -230,7 +230,7 @@ function linestrings(
     markers::Bool=false,
     labels::Bool=false,
     color=nothing
-)::Tuple{Figure, Axis}
+)::Tuple{Figure,Axis}
     fig = Figure(size=(800, 600))
     ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
 
@@ -329,7 +329,7 @@ Create a plot of tender routes within each cluster.
 """
 function tenders(
     tender_soln::Vector{HierarchicalRouting.TenderSolution}
-)::Tuple{Figure, Axis}
+)::Tuple{Figure,Axis}
     fig = Figure(size=(800, 600))
     ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
 
@@ -451,7 +451,7 @@ function solution(
         clusters=soln.cluster_sets[end],
         nodes=true,
         centers=false,
-        labels=false,
+        labels=true,
         cluster_radius=cluster_radius
     )
 

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -136,7 +136,8 @@ function clusters!(
             scatter!(ax, [center_lon], [center_lat], markersize=10, color=(color, 0.2), strokewidth=0)
         end
         if labels
-            text!(ax, center_lon, center_lat, text=string(seq), align=(:center, :center), color=color)
+            seq_id = HierarchicalRouting.generate_letter_id(seq)
+            text!(ax, center_lon, center_lat, text=seq_id, align=(:center, :center), color=color)
         end
     end
     return ax


### PR DESCRIPTION
Use letter ids when plotting clusters to distinguish from waypoints.