### PR TITLE
Refactors plot functions and ensure color matching for clusters and tenders

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ HierarchicalRouting.Plot.exclusions!(ax, problem.mothership.exclusion, labels=tr
 # Add exclusions for tenders
 HierarchicalRouting.Plot.exclusions!(ax, problem.tenders.exclusion, labels=true);
 # Add clustered points
-HierarchicalRouting.Plot.clusters!(ax, clusters=solution_best.cluster_sets[end]);
+HierarchicalRouting.Plot.clusters!(ax, solution_best.cluster_sets[end]);
 # Add mothership routes
 HierarchicalRouting.Plot.route!(
     ax,
@@ -183,8 +183,8 @@ HierarchicalRouting.Plot.exclusions!.(
     labels=false
 );
 # Add clustered points
-HierarchicalRouting.Plot.clusters!(ax1, clusters=solution_init.cluster_sets[end]);
-HierarchicalRouting.Plot.clusters!(ax2, clusters=solution_best.cluster_sets[end]);
+HierarchicalRouting.Plot.clusters!(ax1, solution_init.cluster_sets[end]);
+HierarchicalRouting.Plot.clusters!(ax2, solution_best.cluster_sets[end]);
 # Add mothership routes
 HierarchicalRouting.Plot.route!.(
     [ax1, ax2],
@@ -222,26 +222,20 @@ HierarchicalRouting.Plot.exclusions!.(
 # Add clustered points
 HierarchicalRouting.Plot.clusters!(
     ax1,
-    clusters=solution_best.cluster_sets[end],
+    solution_best.cluster_sets[end],
     labels=true,
-    centers=false,
-    nodes= true,
     cluster_radius=0.025
 );
 HierarchicalRouting.Plot.clusters!(
     ax2,
-    clusters=solution_best.cluster_sets[end],
+    solution_best.cluster_sets[end],
     labels=true,
-    centers=false,
-    nodes= true,
     cluster_radius=0.025
 );
 HierarchicalRouting.Plot.clusters!(
     ax3,
-    clusters=solution_best.cluster_sets[end],
+    solution_best.cluster_sets[end],
     labels=true,
-    centers=false,
-    nodes= true,
     cluster_radius=0.025
 );
 # Add mothership routes

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ HierarchicalRouting.Plot.exclusions!(ax, problem.tenders.exclusion, labels=true)
 # Add clustered points
 HierarchicalRouting.Plot.clusters!(ax, clusters=solution_best.cluster_sets[end]);
 # Add mothership routes
-HierarchicalRouting.Plot.linestrings!(
+HierarchicalRouting.Plot.route!(
     ax,
     solution_best.mothership_routes[end].route,
     color=:black
@@ -186,7 +186,7 @@ HierarchicalRouting.Plot.exclusions!.(
 HierarchicalRouting.Plot.clusters!(ax1, clusters=solution_init.cluster_sets[end]);
 HierarchicalRouting.Plot.clusters!(ax2, clusters=solution_best.cluster_sets[end]);
 # Add mothership routes
-HierarchicalRouting.Plot.linestrings!.(
+HierarchicalRouting.Plot.route!.(
     [ax1, ax2],
     [
         solution_init.mothership_routes[end].route,
@@ -245,7 +245,7 @@ HierarchicalRouting.Plot.clusters!(
     cluster_radius=0.025
 );
 # Add mothership routes
-HierarchicalRouting.Plot.linestrings!.(
+HierarchicalRouting.Plot.route!.(
     [ax1, ax2, ax3],
     [solution_best.mothership_routes[1].route,
      solution_best.mothership_routes[2].route,

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -384,8 +384,8 @@ function tenders!(
     colormap = distinguishable_colors(max_id + 2)[3:end]
 
     # TODO: Plot critical path (longest) thicker than other paths
-    for (t_n, t_soln) in enumerate(tender_soln)
-        base_hue = convert_rgb_to_hue(colormap[t_n])
+    for t_soln in tender_soln
+        base_hue = convert_rgb_to_hue(colormap[t_soln.id])
         s = length(t_soln.sorties)
         palette = sequential_palette(base_hue, s + 3)[3:end]
 

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -14,7 +14,7 @@ using GLMakie, GeoMakie
     clusters(
         ;
         clusters::Union{Vector{HierarchicalRouting.Cluster},Nothing}=nothing,
-        cluster_radius::Real=0,
+        cluster_radius::Union{Float64, Int64}=0,
         nodes::Bool=true,
         centers::Bool=false,
         labels::Bool=false
@@ -22,7 +22,7 @@ using GLMakie, GeoMakie
     clusters(
         ;
         cluster_sequence::Union{DataFrame,Nothing}=nothing,
-        cluster_radius::Real=0,
+        cluster_radius::Union{Float64, Int64}=0,
         centers::Bool=false,
         labels::Bool=false
     )::Tuple{Figure,Axis}
@@ -43,7 +43,7 @@ Create a plot of nodes by cluster.
 function clusters(
     ;
     clusters::Union{Vector{HierarchicalRouting.Cluster},Nothing}=nothing,
-    cluster_radius::Real=0,
+    cluster_radius::Union{Float64,Int64}=0,
     nodes::Bool=true,
     centers::Bool=false,
     labels::Bool=false
@@ -65,7 +65,7 @@ end
 function clusters(
     ;
     cluster_sequence::Union{DataFrame,Nothing}=nothing,
-    cluster_radius::Real=0,
+    cluster_radius::Union{Float64,Int64}=0,
     centers::Bool=false,
     labels::Bool=false
 )::Tuple{Figure,Axis}

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -380,7 +380,8 @@ function tenders!(
     tender_soln::Vector{HierarchicalRouting.TenderSolution}
 )::Axis
     # Create custom colormap, skipping the first two colors (yellow and black)
-    colormap = distinguishable_colors(length(tender_soln) + 2)[3:end]
+    max_id = maximum(getfield.(tender_soln, :id))
+    colormap = distinguishable_colors(max_id + 2)[3:end]
 
     # TODO: Plot critical path (longest) thicker than other paths
     for (t_n, t_soln) in enumerate(tender_soln)

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -254,12 +254,22 @@ end
         labels::Bool=false,
         color=nothing
     )::Axis
+    route!(
+        ax::Axis,
+        ms::HierarchicalRouting.MothershipSolution;
+        markers::Bool=false,
+        labels::Bool=false,
+        color=nothing
+    )::Axis
+    route!(ax::Axis, tender_soln::Vector{HierarchicalRouting.TenderSolution})::Axis
 
 Plot LineStrings for mothership route.
 
 # Arguments
 - `ax`: Axis object.
 - `route`: Route including nodes and LineStrings.
+- `ms`: Solution instance containing mothership route.
+- `tender_soln`: Solution instance containing tender routes.
 - `markers`: Plot waypoints flag.
 - `labels`: Plot LineString labels flag.
 - `color`: LineString color.

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -336,6 +336,22 @@ end
 function route!(ax::Axis, tender_soln::Vector{HierarchicalRouting.TenderSolution})::Axis
     return tenders!(ax, tender_soln)
 end
+function route!(
+    ax::Axis,
+    tender_soln::Vector{HierarchicalRouting.TenderSolution},
+    colormap::Vector{RGB{Colors.FixedPointNumbers.N0f8}}
+)::Axis
+    for t_soln in tender_soln
+        base_hue = convert_rgb_to_hue(colormap[t_soln.id])
+        s = length(t_soln.sorties)
+        palette = sequential_palette(base_hue, s + 3)[3:end]
+
+        for (sortie, color) in zip(t_soln.sorties, palette[1:s])
+            linestrings!(ax, sortie, color=color)
+        end
+    end
+    return ax
+end
 
 """
     tenders(
@@ -387,18 +403,7 @@ function tenders!(
     tender_soln::Vector{HierarchicalRouting.TenderSolution}
 )::Axis
     colormap = create_colormap(getfield.(tender_soln, :id))
-
-    # TODO: Plot critical path (longest) thicker than other paths
-    for t_soln in tender_soln
-        base_hue = convert_rgb_to_hue(colormap[t_soln.id])
-        s = length(t_soln.sorties)
-        palette = sequential_palette(base_hue, s + 3)[3:end]
-
-        for (sortie, color) in zip(t_soln.sorties, palette[1:s])
-            route!(ax, sortie, color=color)
-        end
-    end
-    return ax
+    return route!(ax, tender_soln, colormap)
 end
 function tenders!(
     ax::Axis,
@@ -406,18 +411,7 @@ function tenders!(
     num_clusters::Int64
 )::Axis
     colormap = create_colormap(collect(1:num_clusters))
-
-    # TODO: Plot critical path (longest) thicker than other paths
-    for t_soln in tender_soln
-        base_hue = convert_rgb_to_hue(colormap[t_soln.id])
-        s = length(t_soln.sorties)
-        palette = sequential_palette(base_hue, s + 3)[3:end]
-
-        for (sortie, color) in zip(t_soln.sorties, palette[1:s])
-            route!(ax, sortie, color=color)
-        end
-    end
-    return ax
+    return route!(ax, tender_soln, colormap)
 end
 
 """

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -138,18 +138,15 @@ function clusters!(
     colormap = create_colormap(sequence_ids)
     circle_offsets = _calc_radius_offset(cluster_radius)
 
-    for (idx, seq) in enumerate(sequence_id)
+    for seq in sequence_ids
         color = colormap[seq]
 
-        # plot nodes
-        if nodes && !isnothing(clusters) && !isempty(clusters[seq].nodes)
+        # Plot nodes
+        if !isnothing(clusters) && nodes
             scatter!(ax, clusters[seq].nodes, color=color, markersize=10, marker=:x)
         end
 
-        center_lon, center_lat = isnothing(cluster_sequence) ?
-                                 centroids[seq] :
-                                 centroids[idx]
-
+        center_lon, center_lat = centroids[seq]
         if cluster_radius > 0
             circle_lons = center_lon .+ circle_offsets[1]
             circle_lats = center_lat .+ circle_offsets[2]
@@ -160,6 +157,7 @@ function clusters!(
         if centers
             scatter!(ax, [center_lon], [center_lat], markersize=10, color=(color, 0.2), strokewidth=0)
         end
+
         if labels
             text!(
                 ax,
@@ -173,6 +171,7 @@ function clusters!(
             )
         end
     end
+
     return ax
 end
 

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -523,11 +523,11 @@ function solution(
     # Clusters
     clusters!(
         ax,
-        clusters=soln.cluster_sets[end],
+        soln.cluster_sets[end];
         nodes=true,
         centers=false,
         labels=true,
-        cluster_radius=cluster_radius
+        cluster_radius
     )
 
     # Mothership route

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -98,16 +98,16 @@ end
 
 """
     clusters!(
-        ax::Axis,
-        clusters::Union{Vector{HierarchicalRouting.Cluster},Nothing};
+        ax::Axis;
+        clusters::Union{Vector{HierarchicalRouting.Cluster},Nothing},
         cluster_radius::Float64=0.0,
         nodes::Bool=true,
         centers::Bool=false,
         labels::Bool=false
     )::Axis
     clusters!(
-        ax::Axis,
-        cluster_sequence::Union{DataFrame,Nothing};
+        ax::Axis;
+        cluster_sequence::Union{DataFrame,Nothing},
         cluster_radius::Float64=0.0,
         centers::Bool=false,
         labels::Bool=false
@@ -140,8 +140,8 @@ Plot nodes by cluster.
 - `ax`: Axis object.
 """
 function clusters!(
-    ax::Axis,
-    clusters::Union{Vector{HierarchicalRouting.Cluster},Nothing};
+    ax::Axis;
+    clusters::Union{Vector{HierarchicalRouting.Cluster},Nothing},
     cluster_radius::Float64=0.0,
     nodes::Bool=true,
     centers::Bool=false,
@@ -153,8 +153,8 @@ function clusters!(
     return clusters!(ax, cluster_radius, sequence_ids, centroids, centers, labels; nodes, clusters)
 end
 function clusters!(
-    ax::Axis,
-    cluster_sequence::Union{DataFrame,Nothing};
+    ax::Axis;
+    cluster_sequence::Union{DataFrame,Nothing},
     cluster_radius::Float64=0.0,
     centers::Bool=false,
     labels::Bool=false
@@ -522,8 +522,8 @@ function solution(
 
     # Clusters
     clusters!(
-        ax,
-        soln.cluster_sets[end];
+        ax;
+        clusters=soln.cluster_sets[end],
         nodes=true,
         centers=false,
         labels=true,

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -97,16 +97,14 @@ function clusters!(
         error("At least one of `clusters` or `cluster_sequence` must be provided.")
     end
 
-    sequence_id, colormap, centroids = nothing, nothing, nothing
-    if !isnothing(cluster_sequence)
-        sequence_id = [row.id for row in eachrow(cluster_sequence)[2:end-1]]
-        colormap = distinguishable_colors(length(sequence_id) + 2)[3:end]
-        centroids = hcat(cluster_sequence.lon, cluster_sequence.lat)[2:end-1, :]
-    elseif !isnothing(clusters)
-        sequence_id = 1:length(clusters)
-        colormap = distinguishable_colors(length(clusters) + 2)[3:end]
-        centroids = hcat([cluster.centroid[1] for cluster in clusters], [cluster.centroid[2] for cluster in clusters])
-    end
+    sequence_id = isnothing(cluster_sequence) ?
+                  (1:length(clusters)) :
+                  cluster_sequence.id[2:end-1]
+    centroids = isnothing(cluster_sequence) ?
+                getfield.(clusters, :centroid) :
+                collect(zip(cluster_sequence.lon, cluster_sequence.lat))[2:end-1]
+    max_id = maximum(sequence_id)
+    colormap = distinguishable_colors(max_id + 2)[3:end]
 
     circle_offsets = cluster_radius > 0 ? (
         cluster_radius .* cos.(range(0, 2π, length=100)),

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -37,7 +37,6 @@ Create a plot of nodes by cluster.
 function clusters(
     ;
     clusters::Union{Vector{HierarchicalRouting.Cluster},Nothing}=nothing,
-    cluster_sequence::Union{DataFrame,Nothing}=nothing,
     cluster_radius::Real=0,
     nodes::Bool=true,
     centers::Bool=false,
@@ -48,12 +47,31 @@ function clusters(
 
     clusters!(
         ax,
-        clusters=clusters,
-        cluster_sequence=cluster_sequence,
-        cluster_radius=cluster_radius,
-        nodes=nodes,
-        centers=centers,
-        labels=labels
+        clusters,
+        cluster_radius,
+        nodes,
+        centers,
+        labels
+    )
+
+    return fig, ax
+end
+function clusters(
+    ;
+    cluster_sequence::Union{DataFrame,Nothing}=nothing,
+    cluster_radius::Real=0,
+    centers::Bool=false,
+    labels::Bool=false
+)::Tuple{Figure,Axis}
+    fig = Figure(size=(800, 600))
+    ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
+
+    clusters!(
+        ax,
+        cluster_sequence;
+        cluster_radius,
+        centers,
+        labels
     )
 
     return fig, ax

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -14,12 +14,18 @@ using GLMakie, GeoMakie
     clusters(
         ;
         clusters::Union{Vector{HierarchicalRouting.Cluster},Nothing}=nothing,
-        cluster_sequence::Union{DataFrame,Nothing}=nothing,
         cluster_radius::Real=0,
         nodes::Bool=true,
         centers::Bool=false,
         labels::Bool=false
-    )::Tuple{Figure, Axis}
+    )::Tuple{Figure,Axis}
+    clusters(
+        ;
+        cluster_sequence::Union{DataFrame,Nothing}=nothing,
+        cluster_radius::Real=0,
+        centers::Bool=false,
+        labels::Bool=false
+    )::Tuple{Figure,Axis}
 
 Create a plot of nodes by cluster.
 
@@ -92,13 +98,29 @@ end
 
 """
     clusters!(
-        ax::Axis;
-        clusters::Union{Vector{HierarchicalRouting.Cluster},Nothing}=nothing,
-        cluster_sequence::Union{DataFrame,Nothing}=nothing,
-        cluster_radius::Real=0,
+        ax::Axis,
+        clusters::Union{Vector{HierarchicalRouting.Cluster},Nothing};
+        cluster_radius::Float64=0.0,
         nodes::Bool=true,
         centers::Bool=false,
         labels::Bool=false
+    )::Axis
+    clusters!(
+        ax::Axis,
+        cluster_sequence::Union{DataFrame,Nothing};
+        cluster_radius::Float64=0.0,
+        centers::Bool=false,
+        labels::Bool=false
+    )::Axis
+    clusters!(
+        ax::Axis,
+        cluster_radius::Float64,
+        sequence_ids::Vector{Int},
+        centroids::Vector{NTuple{2,Float64}},
+        centers::Bool=false,
+        labels::Bool=false;
+        nodes=false,
+        clusters=nothing
     )::Axis
 
 Plot nodes by cluster.
@@ -108,6 +130,8 @@ Plot nodes by cluster.
 - `clusters`: Clusters to plot.
 - `cluster_sequence`: Cluster by sequence visited.
 - `cluster_radius`: Radius of circle to represent clusters.
+- `sequence_ids`: Sequence IDs for clusters.
+- `centroids`: Cluster centroids.
 - `nodes`: Plot nodes flag.
 - `centers`: Plot cluster centers flag.
 - `labels`: Plot cluster labels flag.

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -469,7 +469,7 @@ function tenders!(
     tender_soln::Vector{HierarchicalRouting.TenderSolution},
     num_clusters::Int64
 )::Axis
-    colormap = create_colormap(collect(1:num_clusters))
+    colormap = create_colormap(1:num_clusters)
     return route!(ax, tender_soln, colormap)
 end
 

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -215,7 +215,7 @@ function exclusions!(
 end
 
 """
-    linestrings(
+    route(
         route::HierarchicalRouting.Route;
         markers::Bool=false,
         labels::Bool=false,
@@ -233,7 +233,7 @@ Create a plot of LineStrings for mothership route.
 # Returns
 - `fig, ax`: Figure and Axis objects.
 """
-function linestrings(
+function route(
     route::HierarchicalRouting.Route;
     markers::Bool=false,
     labels::Bool=false,
@@ -242,12 +242,12 @@ function linestrings(
     fig = Figure(size=(800, 600))
     ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
 
-    linestrings!(ax, route, markers=markers, labels=labels, color=color)
+    route!(ax, route, markers=markers, labels=labels, color=color)
 
     return fig, ax
 end
 """
-    linestrings!(
+    route!(
         ax::Axis,
         route::HierarchicalRouting.Route;
         markers::Bool=false,
@@ -267,7 +267,7 @@ Plot LineStrings for mothership route.
 # Returns
 - `ax`: Axis object.
 """
-function linestrings!(
+function route!(
     ax::Axis,
     route::HierarchicalRouting.Route;
     markers::Bool=false,
@@ -315,7 +315,7 @@ function route!(
     labels::Bool=false,
     color=nothing
 )
-    return linestrings!(ax, ms.route; markers, labels, color)
+    return route!(ax, ms.route; markers, labels, color)
 end
 
 function route!(ax::Axis, tender_soln::Vector{HierarchicalRouting.TenderSolution})
@@ -381,7 +381,7 @@ function tenders!(
         palette = sequential_palette(base_hue, s + 3)[3:end]
 
         for (sortie, color) in zip(t_soln.sorties, palette[1:s])
-            linestrings!(ax, sortie, color=color)
+            route!(ax, sortie, color=color)
         end
     end
     return ax
@@ -400,7 +400,7 @@ function tenders!(
         palette = sequential_palette(base_hue, s + 3)[3:end]
 
         for (sortie, color) in zip(t_soln.sorties, palette[1:s])
-            linestrings!(ax, sortie, color=color)
+            route!(ax, sortie, color=color)
         end
     end
     return ax
@@ -483,5 +483,5 @@ function convert_rgb_to_hue(base_color::RGB{Colors.FixedPointNumbers.N0f8})
     return ColorTypes.HSV(base_color_float64).h
 end
 
-export clusters, clusters!, exclusions, exclusions!, linestrings, linestrings!, tenders, tenders!
+export clusters, clusters!, exclusions, exclusions!, route, route!, tenders, tenders!
 end

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -106,10 +106,12 @@ function clusters!(
     max_id = maximum(sequence_id)
     colormap = distinguishable_colors(max_id + 2)[3:end]
 
-    circle_offsets = cluster_radius > 0 ? (
-        cluster_radius .* cos.(range(0, 2π, length=100)),
-        cluster_radius .* sin.(range(0, 2π, length=100))
-    ) : nothing
+    circle_offsets = cluster_radius > 0 ?
+                     (
+                        cluster_radius .* cos.(range(0, 2π, length=100)),
+                        cluster_radius .* sin.(range(0, 2π, length=100))
+                     ) :
+                     nothing
 
     for (idx, seq) in enumerate(sequence_id)
         color = colormap[seq]

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -121,9 +121,9 @@ function clusters!(
             scatter!(ax, clusters[seq].nodes, color=color, markersize=10, marker=:x)
         end
 
-        center_lon, center_lat = !isnothing(cluster_sequence) ?
-                                 centroids[idx, :] :
-                                 centroids[seq, :]
+        center_lon, center_lat = isnothing(cluster_sequence) ?
+                                 centroids[seq] :
+                                 centroids[idx]
 
         if cluster_radius > 0
             circle_lons = center_lon .+ circle_offsets[1]

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -117,9 +117,7 @@ function clusters!(
     centroids = isnothing(cluster_sequence) ?
                 getfield.(clusters, :centroid) :
                 collect(zip(cluster_sequence.lon, cluster_sequence.lat))[2:end-1]
-    max_id = maximum(sequence_id)
-    colormap = distinguishable_colors(max_id + 2)[3:end]
-
+    colormap = create_colormap(sequence_ids)
     circle_offsets = _calc_radius_offset(cluster_radius)
 
     for (idx, seq) in enumerate(sequence_id)
@@ -388,9 +386,7 @@ function tenders!(
     ax::Axis,
     tender_soln::Vector{HierarchicalRouting.TenderSolution}
 )::Axis
-    # Create custom colormap, skipping the first two colors (yellow and black)
-    max_id = maximum(getfield.(tender_soln, :id))
-    colormap = distinguishable_colors(max_id + 2)[3:end]
+    colormap = create_colormap(getfield.(tender_soln, :id))
 
     # TODO: Plot critical path (longest) thicker than other paths
     for t_soln in tender_soln
@@ -409,7 +405,7 @@ function tenders!(
     tender_soln::Vector{HierarchicalRouting.TenderSolution},
     num_clusters::Int64
 )::Axis
-    colormap = distinguishable_colors(num_clusters + 2)[3:end]
+    colormap = create_colormap(collect(1:num_clusters))
 
     # TODO: Plot critical path (longest) thicker than other paths
     for t_soln in tender_soln
@@ -490,6 +486,16 @@ function solution(
     show_tenders && route!(ax, soln.tenders[end])
 
     return fig
+end
+
+function create_colormap(ids::Vector{Int})::Vector{RGB{Colors.FixedPointNumbers.N0f8}}
+    # Create custom colormap, skipping the first two colors (yellow and black)
+    max_id = maximum(ids)
+    colormap = distinguishable_colors(max_id + 2)[3:end]
+    return colormap
+end
+function create_colormap(ids::UnitRange{Int64})
+    return create_colormap(collect(ids))
 end
 
 function convert_rgb_to_hue(base_color::RGB{Colors.FixedPointNumbers.N0f8})

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -307,18 +307,16 @@ function route!(
     end
     return ax
 end
-
 function route!(
     ax::Axis,
     ms::HierarchicalRouting.MothershipSolution;
     markers::Bool=false,
     labels::Bool=false,
     color=nothing
-)
+)::Axis
     return route!(ax, ms.route; markers, labels, color)
 end
-
-function route!(ax::Axis, tender_soln::Vector{HierarchicalRouting.TenderSolution})
+function route!(ax::Axis, tender_soln::Vector{HierarchicalRouting.TenderSolution})::Axis
     return tenders!(ax, tender_soln)
 end
 

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -58,6 +58,20 @@ function clusters(
 
     return fig, ax
 end
+
+function _calc_radius_offset(radius::Float64)::Union{Tuple,Nothing}
+    offsets = if radius > 0
+        (
+            radius .* cos.(range(0, 2π, length=100)),
+            radius .* sin.(range(0, 2π, length=100))
+        )
+    else
+        nothing
+    end
+
+    return offsets
+end
+
 """
     clusters!(
         ax::Axis;
@@ -106,12 +120,7 @@ function clusters!(
     max_id = maximum(sequence_id)
     colormap = distinguishable_colors(max_id + 2)[3:end]
 
-    circle_offsets = cluster_radius > 0 ?
-                     (
-                        cluster_radius .* cos.(range(0, 2π, length=100)),
-                        cluster_radius .* sin.(range(0, 2π, length=100))
-                     ) :
-                     nothing
+    circle_offsets = _calc_radius_offset(cluster_radius)
 
     for (idx, seq) in enumerate(sequence_id)
         color = colormap[seq]

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -116,7 +116,7 @@ end
         ax::Axis,
         cluster_radius::Float64,
         sequence_ids::Vector{Int},
-        centroids::Vector{NTuple{2,Float64}},
+        centroids::Vector{Point{2,Float64}},
         centers::Bool=false,
         labels::Bool=false;
         nodes=false,
@@ -171,7 +171,7 @@ function clusters!(
     ax::Axis,
     cluster_radius::Float64,
     sequence_ids::Vector{Int},
-    centroids::Vector{NTuple{2,Float64}},
+    centroids::Vector{Point{2,Float64}},
     centers::Bool=false,
     labels::Bool=false;
     nodes=false,


### PR DESCRIPTION
- Refactors `clusters!()` and `tenders!()`

- Splits `clusters()` and `clusters!()` into multiple methods to handle different input types (clusters, cluster sequences).
- Refactors cluster data extraction for clarity and efficiency.
- Introduces `create_colormap()` to centralize colormap generation for tenders and clusters based on IDs.
- Uses maximum ID for color mapping, to ensure:
  - mismatch does not occur, and 
  - consistent colors of clusters and tenders across plots.
- Functions out `route!()` to improve code reuse within `tenders!()`.
- Improves cluster plotting with better centroid indexing and radius calculation.
- Corrects centroid type as `Point`s.

Closes #72 