### PR TITLE
Renames plotting methods 

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ HierarchicalRouting.Plot.exclusions!(ax, problem.tenders.exclusion, labels=true)
 # Add clustered points
 HierarchicalRouting.Plot.clusters!(ax, clusters=solution_best.cluster_sets[end]);
 # Add mothership routes
-HierarchicalRouting.Plot.linestrings!(
+HierarchicalRouting.Plot.route!(
     ax,
     solution_best.mothership_routes[end].route,
     color=:black
@@ -186,7 +186,7 @@ HierarchicalRouting.Plot.exclusions!.(
 HierarchicalRouting.Plot.clusters!(ax1, clusters=solution_init.cluster_sets[end]);
 HierarchicalRouting.Plot.clusters!(ax2, clusters=solution_best.cluster_sets[end]);
 # Add mothership routes
-HierarchicalRouting.Plot.linestrings!.(
+HierarchicalRouting.Plot.route!.(
     [ax1, ax2],
     [
         solution_init.mothership_routes[end].route,
@@ -245,7 +245,7 @@ HierarchicalRouting.Plot.clusters!(
     cluster_radius=0.025
 );
 # Add mothership routes
-HierarchicalRouting.Plot.linestrings!.(
+HierarchicalRouting.Plot.route!.(
     [ax1, ax2, ax3],
     [solution_best.mothership_routes[1].route,
      solution_best.mothership_routes[2].route,

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -254,12 +254,22 @@ end
         labels::Bool=false,
         color=nothing
     )::Axis
+    route!(
+        ax::Axis,
+        ms::HierarchicalRouting.MothershipSolution;
+        markers::Bool=false,
+        labels::Bool=false,
+        color=nothing
+    )::Axis
+    route!(ax::Axis, tender_soln::Vector{HierarchicalRouting.TenderSolution})::Axis
 
 Plot LineStrings for mothership route.
 
 # Arguments
 - `ax`: Axis object.
 - `route`: Route including nodes and LineStrings.
+- `ms`: Solution instance containing mothership route.
+- `tender_soln`: Solution instance containing tender routes.
 - `markers`: Plot waypoints flag.
 - `labels`: Plot LineString labels flag.
 - `color`: LineString color.

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -215,7 +215,7 @@ function exclusions!(
 end
 
 """
-    linestrings(
+    route(
         route::HierarchicalRouting.Route;
         markers::Bool=false,
         labels::Bool=false,
@@ -233,7 +233,7 @@ Create a plot of LineStrings for mothership route.
 # Returns
 - `fig, ax`: Figure and Axis objects.
 """
-function linestrings(
+function route(
     route::HierarchicalRouting.Route;
     markers::Bool=false,
     labels::Bool=false,
@@ -242,12 +242,12 @@ function linestrings(
     fig = Figure(size=(800, 600))
     ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
 
-    linestrings!(ax, route, markers=markers, labels=labels, color=color)
+    route!(ax, route, markers=markers, labels=labels, color=color)
 
     return fig, ax
 end
 """
-    linestrings!(
+    route!(
         ax::Axis,
         route::HierarchicalRouting.Route;
         markers::Bool=false,
@@ -267,7 +267,7 @@ Plot LineStrings for mothership route.
 # Returns
 - `ax`: Axis object.
 """
-function linestrings!(
+function route!(
     ax::Axis,
     route::HierarchicalRouting.Route;
     markers::Bool=false,
@@ -315,7 +315,7 @@ function route!(
     labels::Bool=false,
     color=nothing
 )
-    return linestrings!(ax, ms.route; markers, labels, color)
+    return route!(ax, ms.route; markers, labels, color)
 end
 
 function route!(ax::Axis, tender_soln::Vector{HierarchicalRouting.TenderSolution})
@@ -381,7 +381,7 @@ function tenders!(
         palette = sequential_palette(base_hue, s + 3)[3:end]
 
         for (sortie, color) in zip(t_soln.sorties, palette[1:s])
-            linestrings!(ax, sortie, color=color)
+            route!(ax, sortie, color=color)
         end
     end
     return ax
@@ -400,7 +400,7 @@ function tenders!(
         palette = sequential_palette(base_hue, s + 3)[3:end]
 
         for (sortie, color) in zip(t_soln.sorties, palette[1:s])
-            linestrings!(ax, sortie, color=color)
+            route!(ax, sortie, color=color)
         end
     end
     return ax
@@ -483,5 +483,5 @@ function convert_rgb_to_hue(base_color::RGB{Colors.FixedPointNumbers.N0f8})
     return ColorTypes.HSV(base_color_float64).h
 end
 
-export clusters, clusters!, exclusions, exclusions!, linestrings, linestrings!, tenders, tenders!
+export clusters, clusters!, exclusions, exclusions!, route, route!, tenders, tenders!
 end

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -307,18 +307,16 @@ function route!(
     end
     return ax
 end
-
 function route!(
     ax::Axis,
     ms::HierarchicalRouting.MothershipSolution;
     markers::Bool=false,
     labels::Bool=false,
     color=nothing
-)
+)::Axis
     return route!(ax, ms.route; markers, labels, color)
 end
-
-function route!(ax::Axis, tender_soln::Vector{HierarchicalRouting.TenderSolution})
+function route!(ax::Axis, tender_soln::Vector{HierarchicalRouting.TenderSolution})::Axis
     return tenders!(ax, tender_soln)
 end
 

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -277,12 +277,12 @@ function optimize_waypoints(
             last_ms_route.route.nodes[end]  # last waypoint (depot)
         ])
 
-        soln_proposed = rebuild_solution_with_waypoints(soln, wpts, exclusions_mothership)
+        soln_proposed = rebuild_solution_with_waypoints(soln, wpts, exclusions_mothership.geometry)
 
         score = critical_path(soln_proposed, vessel_weightings)
 
         # Penalise by an `exclusion_count` factor of `penalty`.
-        exclusion_count = sum(point_in_exclusion.(wpts, Ref(exclusions_mothership)))
+        exclusion_count = sum(point_in_exclusion.(wpts, Ref(exclusions_mothership.geometry)))
         return score + score * exclusion_count
     end
 
@@ -322,7 +322,7 @@ function optimize_waypoints(
     )
 
     # Rebuild solution with the optimal waypoints
-    soln_opt::MSTSolution = rebuild_solution_with_waypoints(soln, x_best, exclusions_mothership)
+    soln_opt::MSTSolution = rebuild_solution_with_waypoints(soln, x_best, exclusions_mothership.geometry)
 
     # Regenerate tender sorties
     ms_route_opt::MothershipSolution = soln_opt.mothership_routes[end]
@@ -347,7 +347,7 @@ end
     rebuild_solution_with_waypoints(
         solution_ex::MSTSolution,
         waypoints_proposed::Vector{Point{2,Float64}},
-        exclusions_mothership::DataFrame
+        exclusions_mothership::POLY_VEC
     )::MSTSolution
 
 Rebuild full `MSTSolution` with updated waypoints and other attributes.
@@ -355,7 +355,7 @@ Rebuild full `MSTSolution` with updated waypoints and other attributes.
 # Arguments
 - `solution_ex`: The existing MSTSolution to be updated.
 - `waypoints_proposed`: Vector of proposed waypoints to update the mothership route.
-- `exclusions_mothership`: DataFrame containing exclusion zones for the mothership.
+- `exclusions_mothership`: Exclusion zone polygons for the mothership.
 
 # Returns
 A new MSTSolution with the updated mothership route and tender sorties.
@@ -363,7 +363,7 @@ A new MSTSolution with the updated mothership route and tender sorties.
 function rebuild_solution_with_waypoints(
     solution_ex::MSTSolution,
     waypoints_proposed::Vector{Point{2,Float64}},
-    exclusions_mothership::DataFrame
+    exclusions_mothership::POLY_VEC
 )::MSTSolution
     # Update the waypoints in the mothership route
     dist_vector_proposed, line_strings_proposed = get_feasible_vector(


### PR DESCRIPTION
Updates plot module by 
renaming `linestrings()` to `route()` and 
adding multiple dispatch and docstrings for `route!()`
to improve clarity and consistency by adopting a more descriptive name.

Updates README documentation and examples to reflect the new naming scheme.

Closes #74 