### PR TITLE
Removes the overloaded `mothership_dist_between_clusts()`

### DIFF
--- a/src/optimization/metric_calcs.jl
+++ b/src/optimization/metric_calcs.jl
@@ -136,17 +136,12 @@ Optionally, the number of clusters can be specified to limit the calculation to 
 - The sum of (haversine) mothership distances between clusters.
 """
 function mothership_dist_between_clusts(route::Route, num_clusters::Int=0)::Float64
-    start_segment_points::Vector{Point{2, Float64}} = route.nodes[1:2:end-1]
-    end_segment_points::Vector{Point{2, Float64}} = route.nodes[2:2:end]
+    start_segment_points::Vector{Point{2,Float64}} = route.nodes[1:2:end-1]
+    end_segment_points::Vector{Point{2,Float64}} = route.nodes[2:2:end]
 
     n = iszero(num_clusters) ? length(start_segment_points) : num_clusters
 
     return sum(haversine.(start_segment_points[1:n], end_segment_points[1:n]))
-end
-function mothership_dist_between_clusts(route::Route, num_clusters::Int)::Float64
-    start_segment_points::Vector{Point{2,Float64}} = route.nodes[1:2:end-1][1:num_clusters]
-    end_segment_points::Vector{Point{2,Float64}} = route.nodes[2:2:end][1:num_clusters]
-    return sum(haversine.(start_segment_points, end_segment_points))
 end
 
 """


### PR DESCRIPTION
Single implementation correctly handles `num_clusters` argument for both cases,
avoiding redundant logic and improving clarity.
Corrects duplicated method wrongly kept from [3097803](https://github.com/ryu-AIMS/HierarchicalRouting.jl/commit/3097803dd7a0d92fd180feaca14adf410645f07f)
