### PR TITLE
Fixes show method errors

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -64,6 +64,15 @@ function Base.show(io::IO, mime::MIME"text/plain", tender::TenderSolution)
         """
     )
 end
+function Base.show(io::IO, mime::MIME"text/plain", tenders::Vector{TenderSolution})
+    n = length(tenders)
+    println(io, "$n tenders:")
+
+    for tender in tenders
+        show(io, mime, tender)
+        print(io, "\n")
+    end
+end
 
 function Base.show(io::IO, mime::MIME"text/plain", soln::MSTSolution)
     nclust = length(soln.cluster_sets[end])

--- a/src/show.jl
+++ b/src/show.jl
@@ -53,9 +53,6 @@ function Base.show(io::IO, mime::MIME"text/plain", mothership::MothershipSolutio
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", tender::TenderSolution)
-    # nclust = nrows(mothership.cluster_sequence)
-    sequence::DataFrame = mothership.cluster_sequence
-
     println(
         io,
         """
@@ -64,8 +61,6 @@ function Base.show(io::IO, mime::MIME"text/plain", tender::TenderSolution)
             Start location: $(tender.start)
             Finish location: $(tender.finish)
             Number of sorties: $(length(tender.sorties))
-
-            Cluster visitation sequence: $(sequence.id)
         """
     )
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -38,7 +38,6 @@ function Base.show(io::IO, mime::MIME"text/plain", clusters::Vector{Cluster})
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", mothership::MothershipSolution)
-    # nclust = nrows(mothership.cluster_sequence)
     sequence::DataFrame = mothership.cluster_sequence
 
     println(


### PR DESCRIPTION
Corrects `TenderSolution` show method, where wrongly copied variables/attributes were causing errors.
Adds a show method for `Vector{TenderSolution}` directly.