### PR TITLE
Avoids solution rebuild when route is infeasible

### DIFF
--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -308,7 +308,7 @@ function optimize_waypoints(
         has_bad_waypoint = point_in_exclusion.(wpts, Ref(exclusions_mothership))
         exclusion_count = count(has_bad_waypoint)
         if any(has_bad_waypoint)
-            naive_score = sum(haversine.(wpts[1:end-1], wpts[2:end]))
+            naive_score = sum(haversine.(wpts[1:end-1], wpts[2:end])) * vessel_weightings[1]
             return naive_score + naive_score * exclusion_count
         end
 


### PR DESCRIPTION
Avoids the expensive solution rebuild process by storing the best solution found so far and only updating it if a better, feasible solution is found during the optimization process.

Adds an early exit process if any infeasible waypoints (i.e., within an exclusion zone) are found.

This also adds a counter to track how many times the best solution has been updated - a temporary inclusion to help with debugging.