### PR TITLE
Corrects and refactors tender sortie rebuild process

### DIFF
--- a/src/processing/processing.jl
+++ b/src/processing/processing.jl
@@ -62,3 +62,42 @@ function create_disturbance_data_dataframe(
     disturbance_values = get_disturbance_value.(nodes, Ref(disturbance_data))
     return DataFrame(node=nodes, disturbance_value=disturbance_values)
 end
+
+"""
+    linestring_segment_to_keep(
+        section::Symbol,
+        point::Point{2,Float64},
+        line_strings::Vector{LineString{2,Float64}},
+    )::Vector{LineString{2,Float64}}
+
+Return the segment of line strings that contains the specified point, either from the start
+or to the end of the line strings.
+
+# Arguments
+- `section`: A symbol indicating whether to keep the segment from the start (`:from`) or to the end (`:to`).
+- `point`: The point to check against the line strings.
+- `line_strings`: A vector of line strings to search through.
+
+# Returns
+- A vector of line strings that contain the specified point in the specified section.
+"""
+function linestring_segment_to_keep(
+    section::Symbol,
+    point::Point{2,Float64},
+    line_strings::Vector{LineString{2,Float64}},
+)::Vector{LineString{2,Float64}}
+    linestring_points = getfield.(line_strings, :points)
+    if section == :from
+        start_seg_points = getindex.(linestring_points, 1)
+        leg_start_idx = findfirst(==(point), start_seg_points)
+        segment = line_strings[leg_start_idx:end]
+        return segment
+    elseif section == :to
+        end_seg_points = getindex.(linestring_points, 2)
+        leg_end_idx = findfirst(==(point), end_seg_points)
+        segment = line_strings[1:leg_end_idx]
+        return segment
+    else
+        error("Invalid section specified. Use `:from` or `:to`")
+    end
+end

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -475,7 +475,7 @@ function generate_tender_sorties(
         # Rebuild the sorties with new start/finish points
         updated_sorties = Vector{Route}(undef, length(tender_old.sorties))
 
-        for (j, route) in enumerate(tender_old.sorties)
+        for (k, route) in enumerate(tender_old.sorties)
             updated_linestrings = Vector{LineString{2,Float64}}()
 
             if tender_old.start != start_new
@@ -505,7 +505,7 @@ function generate_tender_sorties(
             end
 
             # TODO: use `dists` to update r.dist_matrix to match new legs
-            updated_sorties[j] = Route(
+            updated_sorties[k] = Route(
                 route.nodes,
                 route.dist_matrix,
                 updated_linestrings

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -322,19 +322,19 @@ function optimize_waypoints(
         # score = critical_path(soln_proposed, vessel_weightings)
         score = critical_distance_path(soln_proposed, vessel_weightings)
 
-        # Penalise by an `exclusion_count` factor of `penalty`.
-        actual_score = score + score * exclusion_count
+        # Penalize by an `exclusion_count` factor of `penalty`.
+        penalized_score = score + score * exclusion_count
 
-        if actual_score < best_score[]
+        if penalized_score < best_score[]
             best_soln[] = soln_proposed
-            best_score[] = actual_score
+            best_score[] = penalized_score
             best_count[] = 0
         else
             # For debugging and tracking
-            best_count[] = best_count[] + 1
+            best_count[] += 1
         end
 
-        return actual_score
+        return penalized_score
     end
 
     # Run Optim with the provided optimization method.

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -366,10 +366,7 @@ function optimize_waypoints(
     @info "Gradient status:" Optim.g_converged(result)
     # @info "Gradient trace:" Optim.g_norm_trace(result)
 
-    # Rebuild solution with the optimal waypoints
-    soln_opt::MSTSolution = best_soln[]
-
-    return soln_opt
+    return best_soln[]
 end
 
 """
@@ -590,8 +587,6 @@ function generate_tender_sorties(
 
         # Rebuild the sorties with new start/finish points
         sorties_old = tender_old.sorties
-        sorties_new = Vector{Route}(undef, length(sorties_old))
-
         sorties_new = rebuild_sortie.(
             sorties_old,
             Ref(start_new),

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -467,7 +467,11 @@ function generate_tender_sorties(
         tender_old = tenders_old[j]
         start_new, finish_new = starts_new[j], finishes_new[j]
 
-        if tender_old.start == start_new && tender_old.finish == finish_new
+        sortie_start_has_moved = tender_old.start != start_new
+        sortie_end_has_moved = tender_old.finish != finish_new
+
+        # If neither start nor finish has moved, keep the old tender solution and continue
+        if !sortie_start_has_moved && !sortie_end_has_moved
             tenders_new[j] = tender_old
             continue
         end
@@ -478,7 +482,7 @@ function generate_tender_sorties(
         for (k, route) in enumerate(tender_old.sorties)
             updated_linestrings = Vector{LineString{2,Float64}}()
 
-            if tender_old.start != start_new
+            if sortie_start_has_moved
                 leg_to_update = [start_new, route.nodes[1]]
 
                 old_leg = linestring_segment_to_keep(
@@ -491,7 +495,7 @@ function generate_tender_sorties(
                 updated_linestrings = vcat(new_leg..., old_leg...)
             end
 
-            if tender_old.finish != finish_new
+            if sortie_end_has_moved
                 leg_to_update = [route.nodes[end], finish_new]
 
                 old_leg = linestring_segment_to_keep(

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -477,9 +477,10 @@ function generate_tender_sorties(
         end
 
         # Rebuild the sorties with new start/finish points
-        updated_sorties = Vector{Route}(undef, length(tender_old.sorties))
+        sorties_old = tender_old.sorties
+        sorties_new = Vector{Route}(undef, length(sorties_old))
 
-        for (k, route) in enumerate(tender_old.sorties)
+        for (r, route) in enumerate(sorties_old)
             updated_linestrings = Vector{LineString{2,Float64}}()
 
             if sortie_start_has_moved
@@ -509,7 +510,7 @@ function generate_tender_sorties(
             end
 
             # TODO: use `dists` to update r.dist_matrix to match new legs
-            updated_sorties[k] = Route(
+            sorties_new[r] = Route(
                 route.nodes,
                 route.dist_matrix,
                 updated_linestrings
@@ -520,7 +521,7 @@ function generate_tender_sorties(
             tender_old.id,
             start_new,
             finish_new,
-            updated_sorties,
+            sorties_new,
             tender_old.dist_matrix
         )
     end

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -277,8 +277,6 @@ function optimize_waypoints(
 )::MSTSolution
     exclusions_mothership::POLY_VEC = problem.mothership.exclusion.geometry
     exclusions_tender::POLY_VEC = problem.tenders.exclusion.geometry
-    n_tenders::Int8 = problem.tenders.number
-    t_cap::Int16 = problem.tenders.capacity
     vessel_weightings::NTuple{2,AbstractFloat} = (
         problem.mothership.weighting, problem.tenders.weighting
     )

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -317,8 +317,7 @@ function optimize_waypoints(
             exclusions_tender
         )
 
-        # score = critical_path(soln_proposed, vessel_weightings)
-        score = critical_distance_path(soln_proposed, vessel_weightings)
+        score = critical_path(soln_proposed, vessel_weightings)
 
         # Penalize by an `exclusion_count` factor of `penalty`.
         penalized_score = score + score * exclusion_count

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -308,7 +308,7 @@ function optimize_waypoints(
         has_bad_waypoint = point_in_exclusion.(wpts, Ref(exclusions_mothership))
         exclusion_count = count(has_bad_waypoint)
         if any(has_bad_waypoint)
-            naive_score = sum(haversine.(wpts[1:end-1], wpts[2:end]))
+            naive_score = sum(haversine.(wpts[1:end-1], wpts[2:end])) * vessel_weightings[1]
             return naive_score + naive_score * exclusion_count
         end
 

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -302,7 +302,7 @@ function optimize_waypoints(
             last_ms_route.route.nodes[end]  # last waypoint (depot)
         ])
 
-        # Exit early here if any waypoints are outside exclusion zones
+        # Exit early here if any waypoints are inside exclusion zones
         has_bad_waypoint = point_in_exclusion.(wpts, Ref(exclusions_mothership))
         exclusion_count = count(has_bad_waypoint)
         if any(has_bad_waypoint)
@@ -319,19 +319,15 @@ function optimize_waypoints(
 
         score = critical_path(soln_proposed, vessel_weightings)
 
-        # Penalize by an `exclusion_count` factor of `penalty`.
-        penalized_score = score + score * exclusion_count
-
-        if penalized_score < best_score[]
+        if score < best_score[]
             best_soln[] = soln_proposed
-            best_score[] = penalized_score
+            best_score[] = score
             best_count[] = 0
         else
             # For debugging and tracking
             best_count[] += 1
         end
-
-        return penalized_score
+        return score
     end
 
     # Run Optim with the provided optimization method.

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -420,7 +420,7 @@ function rebuild_solution_with_waypoints(
     )
 
     # Update the tender solutions with the new waypoints
-    tender_soln_new = generate_tender_sorties(solution_ex, adjusted_waypoints)
+    tender_soln_new = generate_tender_sorties(solution_ex, adjusted_waypoints, exclusions_tender)
 
     # Return a new MSTSolution with the updated mothership route
     return MSTSolution(
@@ -433,7 +433,8 @@ end
 """
     generate_tender_sorties(
         soln::MSTSolution,
-        tmp_wpts::Vector{Point{2,Float64}}
+        tmp_wpts::Vector{Point{2,Float64}},
+        exclusions::POLY_VEC
     )::Vector{TenderSolution}
 
 Generate tender sorties based on the updated waypoints, including all updated attributes.
@@ -441,13 +442,15 @@ Generate tender sorties based on the updated waypoints, including all updated at
 # Arguments
 - `soln`: The existing MSTSolution containing tenders.
 - `tmp_wpts`: Vector of temporary waypoints to update the tender sorties.
+- `exclusions`: Exclusion zone polygons for tenders.
 
 # Returns
 Updated TenderSolution objects with new waypoints.
 """
 function generate_tender_sorties(
     soln::MSTSolution,
-    tmp_wpts::Vector{Point{2,Float64}}
+    tmp_wpts::Vector{Point{2,Float64}},
+    exclusions::POLY_VEC
 )::Vector{TenderSolution}
     # Update the tender solutions with the new waypoints
     tender_soln_ex = soln.tenders[end]

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -464,14 +464,14 @@ function generate_tender_sorties(
     tenders_new = Vector{TenderSolution}(undef, n)
 
     for j in js
-        tenders = tenders_old[j]
+        tender_old = tenders_old[j]
         start_new, finish_new = starts_new[j], finishes_new[j]
 
-        if tenders.start != start_new || tenders.finish != finish_new
+        if tender_old.start != start_new || tender_old.finish != finish_new
             # Rebuild the sorties with new start/finish points
-            updated_sorties = Vector{Route}(undef, length(tenders.sorties))
+            updated_sorties = Vector{Route}(undef, length(tender_old.sorties))
 
-            for (j, route) in enumerate(tenders.sorties)
+            for (j, route) in enumerate(tender_old.sorties)
                 seq = [start_new, route.nodes..., finish_new]
                 dists, legs = get_feasible_vector(seq, exclusions)
 
@@ -480,14 +480,14 @@ function generate_tender_sorties(
             end
 
             tenders_new[j] = TenderSolution(
-                tenders.id,
+                tender_old.id,
                 start_new,
                 finish_new,
                 updated_sorties,
-                tenders.dist_matrix
+                tender_old.dist_matrix
             )
         else
-            tenders_new[j] = tenders
+            tenders_new[j] = tender_old
         end
     end
 

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -301,7 +301,7 @@ function optimize_waypoints(
             last_ms_route.route.nodes[end]  # last waypoint (depot)
         ])
 
-        soln_proposed = rebuild_solution_with_waypoints(soln, wpts, exclusions_mothership)
+        soln_proposed = rebuild_solution_with_waypoints(soln, wpts, exclusions_mothership, exclusions_tender)
 
         # score = critical_path(soln_proposed, vessel_weightings)
         score = critical_distance_path(soln_proposed, vessel_weightings)
@@ -351,7 +351,7 @@ function optimize_waypoints(
     ])
 
     # Rebuild solution with the optimal waypoints
-    soln_opt::MSTSolution = rebuild_solution_with_waypoints(soln, x_best, exclusions_mothership)
+    soln_opt::MSTSolution = rebuild_solution_with_waypoints(soln, x_best, exclusions_mothership, exclusions_tender)
 
     # Regenerate tender sorties
     ms_route_opt::MothershipSolution = soln_opt.mothership_routes[end]
@@ -376,7 +376,8 @@ end
     rebuild_solution_with_waypoints(
         solution_ex::MSTSolution,
         waypoints_proposed::Vector{Point{2,Float64}},
-        exclusions_mothership::POLY_VEC
+        exclusions_mothership::POLY_VEC,
+        exclusions_tender::POLY_VEC
     )::MSTSolution
 
 Rebuild full `MSTSolution` with updated waypoints and other attributes.
@@ -385,6 +386,7 @@ Rebuild full `MSTSolution` with updated waypoints and other attributes.
 - `solution_ex`: The existing MSTSolution to be updated.
 - `waypoints_proposed`: Vector of proposed waypoints to update the mothership route.
 - `exclusions_mothership`: Exclusion zone polygons for the mothership.
+- `exclusions_tender`: Exclusion zone polygons for the tenders.
 
 # Returns
 A new MSTSolution with the updated mothership route and tender sorties.
@@ -392,7 +394,8 @@ A new MSTSolution with the updated mothership route and tender sorties.
 function rebuild_solution_with_waypoints(
     solution_ex::MSTSolution,
     waypoints_proposed::Vector{Point{2,Float64}},
-    exclusions_mothership::POLY_VEC
+    exclusions_mothership::POLY_VEC,
+    exclusions_tender::POLY_VEC
 )::MSTSolution
     # Update the waypoints in the mothership route
     adjusted_waypoints = adjust_waypoint.(waypoints_proposed, Ref(exclusions_mothership))


### PR DESCRIPTION
Rebuilds tender sorties after waypoint optimization by checking for changed start and/or sortie points (which are mothership waypoints). If these points have been perturbed, update linestrings in that segment of the tender sortie. Sorties/segments without changes do not need to be updated.

- Corrects tender sortie logic to ensure linestrings adhere to exclusion zone feasibility at each rebuild, rather than ignoring and then rebuilding at end.
- Avoiding unnecessary sortie rebuilds by checking if start/end points have moved
- Rebuilds only necessary segments of line strings, improving performance
- Functions out linestring segmentation and re-calcs in `generate_tender_sorties()` to:
  - `rebuild_sortie()`
    - `update_segment()`
      - `linestring_segment_to_keep()`
- Refactors to improve logic
- Updates variable names for clarity