### PR TITLE
Improves exclusion zone handling to ensure mothership exclusions overlap tenders

### DIFF
--- a/src/problem/problem_setup.jl
+++ b/src/problem/problem_setup.jl
@@ -176,6 +176,14 @@ function load_problem(
         min_area=1E-5
     )
 
+    # Ensure mothership is excluded from tender zones by combining and merging exclusions
+    exclusions_all::POLY_VEC = vcat(
+        ms_exclusions.geometry,
+        t_exclusions.geometry)
+    unionize_overlaps!(exclusions_all)
+    ms_exclusions::DataFrame = DataFrame(geometry=exclusions_all)
+    unionize_overlaps!(ms_exclusions.geometry)
+
     mothership = Vessel(
         exclusion=ms_exclusions,
         weighting=weight_ms

--- a/src/processing/spatial_operations.jl
+++ b/src/processing/spatial_operations.jl
@@ -129,11 +129,11 @@ function unionize_overlaps!(geometries::POLY_VEC)::POLY_VEC
         end
     end
 
-    # Remove duplicate unionized geometries
-    unique_geometries = unique(geometries[.!AG.isempty.(geometries)])
+    filtered = unique(geometries[.!AG.isempty.(geometries)])
+    empty!(geometries)
+    append!(geometries, filtered)
 
-    # Return the unique geometries as a POLY_VEC
-    return unique_geometries
+    return geometries
 end
 function unionize_overlaps!(exclusions::DataFrame)::DataFrame
     geometries = exclusions.geometry

--- a/src/processing/spatial_operations.jl
+++ b/src/processing/spatial_operations.jl
@@ -1,31 +1,34 @@
 
 """
     filter_and_simplify_exclusions!(
-        exclusions::DataFrame;
-        min_area::Float64=3E-5,
-        simplify_tol::Float64=1E-3
-    )::DataFrame
+        exclusion_geometries::POLY_VEC;
+        min_area::Float64=1E-5,
+        simplify_tol::Float64=5E-4
+    )::POLY_VEC
 
 Remove small polygons and simplify geometry based on tolerance values.
 
 # Arguments
-- `exclusions`: The DataFrame containing exclusion zones.
+- `exclusion_geometries`: A vector of polygon geometries to filter and simplify.
 - `min_area`: The minimum area for exclusion polygons.
 - `simplify_tol`: The tolerance value for simplifying the exclusion polygons, \n
     i.e., larger tol = more aggressive simplification.
 """
 function filter_and_simplify_exclusions!(
-    exclusions::DataFrame;
+    exclusion_geometries::POLY_VEC;
     min_area::Float64=1E-5,
-    simplify_tol::Float64=1E-3
-)::DataFrame
-    exclusions.geometry .= AG.simplify.(exclusions.geometry, simplify_tol)
-    filter!(row -> AG.geomarea(row.geometry) >= min_area, exclusions)
-    return exclusions
+    simplify_tol::Float64=5E-4
+)::POLY_VEC
+    exclusion_geometries .= AG.simplify.(exclusion_geometries, simplify_tol)
+    filter!(geom -> AG.geomarea(geom) >= min_area && !AG.isempty(geom), exclusion_geometries)
+    return exclusion_geometries
 end
 
 """
-    buffer_exclusions!(exclusions::DataFrame; buffer_dist::Float64=0.0)::DataFrame
+    buffer_exclusions!(
+        exclusion_geometries::POLY_VEC;
+        buffer_dist::Float64=0.0
+    )::POLY_VEC
 
 Buffer exclusion zones by a specified distance.
 
@@ -33,9 +36,12 @@ Buffer exclusion zones by a specified distance.
 - `exclusions`: The DataFrame containing exclusion zones.
 - `buffer_dist`: The buffer distance.
 """
-function buffer_exclusions!(exclusions::DataFrame; buffer_dist::Float64=0.0)::DataFrame
-    exclusions.geometry .= AG.buffer.(exclusions.geometry, buffer_dist)
-    return exclusions
+function buffer_exclusions!(
+    exclusion_geometries::POLY_VEC;
+    buffer_dist::Float64=0.0
+)::POLY_VEC
+    exclusion_geometries .= AG.buffer.(exclusion_geometries, buffer_dist)
+    return exclusion_geometries
 end
 
 """

--- a/src/processing/spatial_operations.jl
+++ b/src/processing/spatial_operations.jl
@@ -69,15 +69,16 @@ function linestring_to_polygon(
 end
 
 """
+    unionize_overlaps!(geometries::POLY_VEC)::POLY_VEC
     unionize_overlaps(exclusions::DataFrame)::DataFrame
 
 Unionize overlapping exclusion zones.
 
 # Arguments
+- `geometries`: A vector of geometries (polygons) to unionize.
 - `exclusions`: DataFrame containing exclusion zones.
 """
-function unionize_overlaps!(exclusions::DataFrame)::DataFrame
-    geometries = exclusions.geometry
+function unionize_overlaps!(geometries::POLY_VEC)::POLY_VEC
     n = length(geometries)
 
     for i in 1:n
@@ -124,6 +125,13 @@ function unionize_overlaps!(exclusions::DataFrame)::DataFrame
 
     # Remove duplicate unionized geometries
     unique_geometries = unique(geometries[.!AG.isempty.(geometries)])
+
+    # Return the unique geometries as a POLY_VEC
+    return unique_geometries
+end
+function unionize_overlaps!(exclusions::DataFrame)::DataFrame
+    geometries = exclusions.geometry
+    unique_geometries = unionize_overlaps!(geometries)
 
     empty!(exclusions)
     append!(exclusions, [(geometry=geom,) for geom in unique_geometries])

--- a/src/processing/spatial_operations.jl
+++ b/src/processing/spatial_operations.jl
@@ -5,6 +5,11 @@
         min_area::Float64=1E-5,
         simplify_tol::Float64=5E-4
     )::POLY_VEC
+    filter_and_simplify_exclusions(
+        exclusion_geometries::POLY_VEC;
+        min_area::Float64=1E-5,
+        simplify_tol::Float64=5E-4
+    )::POLY_VEC
 
 Remove small polygons and simplify geometry based on tolerance values.
 
@@ -23,9 +28,22 @@ function filter_and_simplify_exclusions!(
     filter!(geom -> AG.geomarea(geom) >= min_area && !AG.isempty(geom), exclusion_geometries)
     return exclusion_geometries
 end
+function filter_and_simplify_exclusions(
+    exclusion_geometries::POLY_VEC;
+    min_area::Float64=1E-5,
+    simplify_tol::Float64=5E-4
+)::POLY_VEC
+    copy_vec = copy(exclusion_geometries)
+    filter_and_simplify_exclusions!(copy_vec; min_area=min_area, simplify_tol=simplify_tol)
+    return copy_vec
+end
 
 """
     buffer_exclusions!(
+        exclusion_geometries::POLY_VEC;
+        buffer_dist::Float64=0.0
+    )::POLY_VEC
+    buffer_exclusions(
         exclusion_geometries::POLY_VEC;
         buffer_dist::Float64=0.0
     )::POLY_VEC
@@ -42,6 +60,14 @@ function buffer_exclusions!(
 )::POLY_VEC
     exclusion_geometries .= AG.buffer.(exclusion_geometries, buffer_dist)
     return exclusion_geometries
+end
+function buffer_exclusions(
+    exclusion_geometries::POLY_VEC;
+    buffer_dist::Float64=0.0
+)::POLY_VEC
+    copy_vec = copy(exclusion_geometries)
+    buffer_exclusions!(copy_vec; buffer_dist=buffer_dist)
+    return copy_vec
 end
 
 """
@@ -76,7 +102,8 @@ end
 
 """
     unionize_overlaps!(geometries::POLY_VEC)::POLY_VEC
-    unionize_overlaps(exclusions::DataFrame)::DataFrame
+    unionize_overlaps(geometries::POLY_VEC)::POLY_VEC
+    unionize_overlaps!(exclusions::DataFrame)::DataFrame
 
 Unionize overlapping exclusion zones.
 
@@ -134,6 +161,11 @@ function unionize_overlaps!(geometries::POLY_VEC)::POLY_VEC
     append!(geometries, filtered)
 
     return geometries
+end
+function unionize_overlaps(geometries::POLY_VEC)::POLY_VEC
+    geoms_copy = copy(geometries)
+    unionize_overlaps!(geoms_copy)
+    return geoms_copy
 end
 function unionize_overlaps!(exclusions::DataFrame)::DataFrame
     geometries = exclusions.geometry


### PR DESCRIPTION
Refactors exclusion zone handling for improved robustness and flexibility.

- Introduces `prepare_exclusion_geoms!()` to encapsulate function out common exclusion preprocessing steps, ensuring consistent handling of both mothership and tender exclusion zones.
- Modifies spatial operation functions to operate on `POLY_VEC`s directly.
- Ensures mothership exclusion zones are strictly excluded from tender exclusion zones - previously not a hard constraint, and problematic due to simplify tolerances.