### PR TITLE
Resolves errors with reading/processing cached files

### DIFF
--- a/src/problem/problem_setup.jl
+++ b/src/problem/problem_setup.jl
@@ -133,9 +133,6 @@ function load_problem(
 
     # Process exclusions
     if !(debug_mode)
-        if !isempty(output_dir)
-            mkpath(output_dir)
-        end
         ms_exclusions = read_and_polygonize_exclusions(
             env_data_path,
             draft_ms,

--- a/src/processing/data_types.jl
+++ b/src/processing/data_types.jl
@@ -80,7 +80,7 @@ function polygonize_binary(rast::Raster)::DataFrame
     # Can't easily pre-allocate the vector as we don't know how many true-valued geoms
     # there are.
     n_features = AG.GDAL.ogr_l_getfeaturecount(layer, 1)
-    layer_geoms = Vector{IGeometry}()
+    layer_geoms = POLY_VEC()
     sizehint!(layer_geoms, n_features)
     for i in 0:(n_features-1)
         feat = AG.Feature(AG.GDAL.ogr_l_getfeature(layer, i))

--- a/src/processing/reads.jl
+++ b/src/processing/reads.jl
@@ -93,6 +93,11 @@ function read_and_polygonize_exclusions(
     file_name::String,
     output_dir::String="",
 )::DataFrame
+    # ensure output directory exists
+    if !isempty(output_dir)
+        mkpath(output_dir)
+    end
+
     exclusion_gpkg_path::String = joinpath(output_dir, "$(file_name).gpkg")
     # TODO: Generalize for all available environmental constraints
     # TODO: Generalize for ms and tender vessels


### PR DESCRIPTION
Specifies a concrete vector type to store geometries as a `POLY_VEC` to avoid potential type instability issues.