### PR TITLE
Addresses compatibility issues and enhances the robustness of the solution process.

### DIFF
--- a/src/optimization/metric_calcs.jl
+++ b/src/optimization/metric_calcs.jl
@@ -177,8 +177,9 @@ function critical_path(
     # Between clusters
     tow_cost = vessel_weightings[1] * mothership_dist_between_clusts(ms_route, num_clusters)
     total_critical_path = cluster_cost_total + tow_cost
-    @assert !isinf(total_critical_path) "Critical path cost is infinite, " *
-                                        "indicating a solution with a bad waypoint"
+    isinf(total_critical_path) && throw(DomainError(total_critical_path,
+        "Critical path cost is infinite, indicating a waypoint in an exclusion zone."
+    ))
     return total_critical_path
 end
 

--- a/src/optimization/metric_calcs.jl
+++ b/src/optimization/metric_calcs.jl
@@ -177,6 +177,15 @@ function critical_path(
 
     # Within clusters
     cluster_sorties = tender_clust_dist.(tenders)
+
+    # Ensure that all sortie distance matrices appear in the tender distance matrices
+    !all(map((u, v) -> all(u .∈ Ref(v)),
+        [vcat(getfield.(t.sorties, :dist_matrix)...) for t in tenders],
+        getfield.(tenders, :dist_matrix)
+    )) && throw(ArgumentError(
+        "Not all sortie distance matrices appear in the tender distance matrices."
+    ))
+
     cluster_sorties = map(x -> isempty(x) ? [0.0] : x, cluster_sorties)
     longest_sortie_cost = maximum.(cluster_sorties) .* vessel_weightings[2]
     mothership_within_clusts = mothership_dist_within_clusts(ms_route)[1:num_clusters]

--- a/src/optimization/metric_calcs.jl
+++ b/src/optimization/metric_calcs.jl
@@ -76,6 +76,10 @@ end
         node_order::Vector{Int64},
         dist_matrix::Matrix{Float64}
     )::Float64
+    tender_sortie_dist(
+        _::Vector{Int64},
+        dist_vector::Vector{Float64}
+    )::Float64
 
 Compute the cost of a sortie, which starts and ends at given points, but does not return to
 start.
@@ -84,6 +88,7 @@ start.
 - `sortie`: Route object containing nodes and distance matrix.
 - `node_order`: Vector of node indices representing the order of the sortie.
 - `dist_matrix`: Distance matrix between nodes, ordered by node index.
+- `dist_vector`: Vector of distances between consecutive nodes in the sortie.
 
 # Returns
 The total distance of the sortie.
@@ -99,6 +104,12 @@ function tender_sortie_dist(
         dist_matrix[node_order[i], node_order[i+1]]
         for i in 1:(length(node_order)-1)
     )
+end
+function tender_sortie_dist(
+    _::Vector{Int64},
+    dist_vector::Vector{Float64}
+)::Float64
+    return sum(dist_vector)
 end
 
 """

--- a/src/optimization/metric_calcs.jl
+++ b/src/optimization/metric_calcs.jl
@@ -176,8 +176,10 @@ function critical_path(
 
     # Between clusters
     tow_cost = vessel_weightings[1] * mothership_dist_between_clusts(ms_route, num_clusters)
-
-    return cluster_cost_total + tow_cost
+    total_critical_path = cluster_cost_total + tow_cost
+    @assert !isinf(total_critical_path) "Critical path cost is infinite, " *
+                                        "indicating a solution with a bad waypoint"
+    return total_critical_path
 end
 
 function critical_distance_path(

--- a/src/optimization/metric_calcs.jl
+++ b/src/optimization/metric_calcs.jl
@@ -151,7 +151,7 @@ end
 """
     critical_path(
         soln::MSTSolution,
-        vessel_weightings::NTuple{2,AbstractFloat}=(1.0, 1.0)
+        vessel_weightings::NTuple{2,AbstractFloat}
     )::Float64
 
 Compute the critical path cost of the solution.
@@ -169,7 +169,7 @@ The total (critical path) cost of the solution.
 """
 function critical_path(
     soln::MSTSolution,
-    vessel_weightings::NTuple{2,AbstractFloat}=(1.0, 1.0)
+    vessel_weightings::NTuple{2,AbstractFloat}
 )::Float64
     tenders = soln.tenders[end]
     ms_route = soln.mothership_routes[end].route

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -488,6 +488,7 @@ end
         show_tenders_exclusions::Bool=true,
         show_mothership::Bool=true,
         show_tenders::Bool=true,
+        highlight_critical_path::Bool=false,
     )::Figure
     solution(
         problem::Problem,
@@ -516,6 +517,7 @@ Create a plot of the full routing solution, including:
 - `show_tenders_exclusions`: Whether to show **tender** exclusion zones.
 - `show_mothership`: Whether to show the **mothership** route.
 - `show_tenders`: Whether to show **tender** routes.
+- `highlight_critical_path`: Whether to highlight the critical path (in red).
 
 # Returns
 The created Figure object containing the plot.
@@ -528,6 +530,7 @@ function solution(
     show_tenders_exclusions::Bool=true,
     show_mothership::Bool=true,
     show_tenders::Bool=true,
+    highlight_critical_path::Bool=false,
 )::Figure
     fig = Figure(size=(750, 880))
     ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
@@ -573,7 +576,7 @@ function solution(
         metric="critical_distance_path()\ntotal dist"
     )
 
-    # highlight_critical_path!(ax, soln, vessel_weightings)
+    highlight_critical_path && highlight_critical_path!(ax, soln, vessel_weightings)
 
     return fig
 end

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -573,7 +573,7 @@ function solution(
         metric="critical_distance_path()\ntotal dist"
     )
 
-    highlight_critical_path!(ax, soln, vessel_weightings)
+    # highlight_critical_path!(ax, soln, vessel_weightings)
 
     return fig
 end
@@ -868,6 +868,40 @@ function convert_rgb_to_hue(base_color::RGB{Colors.FixedPointNumbers.N0f8})
         float(base_color.b)
     )
     return ColorTypes.HSV(base_color_float64).h
+end
+
+# Debug plots
+
+"""
+    debug_waypoints(problem::Problem, wpts::Union{Vector{GeometryBasics.Point{2,Float64}},Vector{Float64}}; title="")
+    debug_waypoints(problem::Problem, wpts::Vector{Float64}; title="")
+
+Plots the exclusion zones alongside indicative waypoints.
+
+# Example
+```julia
+import HierarchicalRouting as HR
+
+x = Problem(...)
+x = [some waypoints in long/lat sequence...]
+HR.Plot.debug_waypoints(problem, x)
+```
+"""
+function debug_waypoints(
+    problem::Problem, wpts::Union{Vector{GeometryBasics.Point{2,Float64}},Vector{Float64}};
+    title=""
+)
+    fig = Figure(size=(750, 880))
+    ax = Axis(fig[1, 1], xlabel="Longitude", ylabel="Latitude")
+    exclusions!(ax, problem.mothership.exclusion; labels=false)
+    exclusions!(ax, problem.tenders.exclusion; labels=false)
+    scatter!(wpts)
+    ax.title = title
+
+    return fig
+end
+function debug_waypoints(problem::Problem, wpts::Vector{Float64}; title="")
+    return debug_waypoints(problem, Point.(wpts[1:2:end], wpts[2:2:end]); title=title)
 end
 
 export clusters, clusters!, exclusions, exclusions!, route, route!, tenders, tenders!

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -285,8 +285,8 @@ function solve(
         # Improve the current solution using the optimization function
         optimized_current_solution, _ = improve_solution(
             MSTSolution([clusters], [ms_route], [current_tender_soln]),
-            problem.mothership.exclusion,
-            problem.tenders.exclusion,
+            problem.mothership.exclusion.geometry,
+            problem.tenders.exclusion.geometry,
             disturbance_cluster_idx, next_disturbance_cluster_idx
         )
 

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -453,15 +453,15 @@ function improve_solution(
     static_limit::Int=20,
     vessel_weightings::NTuple{2,AbstractFloat}=(1.0, 1.0)
 )::Tuple{MSTSolution,Float64}
-    current_mothership_route = initial_solution.mothership_routes[end]
+    current_mothership_route::MothershipSolution = initial_solution.mothership_routes[end]
 
-    cluster_seq_ids = current_mothership_route.cluster_sequence.id
-    clust_seq_current = cluster_seq_ids[current_cluster_idx+1:next_cluster_idx+1]
-    current_clusters = initial_solution.cluster_sets[end][clust_seq_current]
+    cluster_seq_ids::Vector{Int64} = current_mothership_route.cluster_sequence.id
+    clust_seq_current::Vector{Int64} = cluster_seq_ids[current_cluster_idx+1:next_cluster_idx+1]
+    current_clusters::Vector{Cluster} = initial_solution.cluster_sets[end][clust_seq_current]
     sort!(current_clusters, by=c -> c.id)
 
-    current_tender_set = initial_solution.tenders[end]
-    current_tender_routes = current_tender_set[current_cluster_idx:next_cluster_idx]
+    current_tender_set::Vector{TenderSolution} = initial_solution.tenders[end]
+    current_tender_routes::Vector{TenderSolution} = current_tender_set[current_cluster_idx:next_cluster_idx]
 
     current_solution = MSTSolution(
         [current_clusters],

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -75,14 +75,14 @@ function initial_solution(
             )
         )
 
-        removed_nodes = setdiff(
-            vcat([c.nodes for c in cluster_sets[disturbance_index-1]]...),
-            vcat([c.nodes for c in clusters]...)
-        )
-        if !isempty(removed_nodes)
-            @info "Removed nodes due to disturbance event (since previous cluster):\n" *
-                  "\t$(join(removed_nodes, "\n\t"))"
-        end
+        # removed_nodes = setdiff(
+        #     vcat([c.nodes for c in cluster_sets[disturbance_index-1]]...),
+        #     vcat([c.nodes for c in clusters]...)
+        # )
+        # if !isempty(removed_nodes)
+        #     @info "Removed nodes due to disturbance event (since previous cluster):\n" *
+        #           "\t$(join(removed_nodes, "\n\t"))"
+        # end
 
         sort!(clusters, by=x -> x.id)
 
@@ -235,14 +235,14 @@ function solve(
             ), by=x -> x.id
         )
 
-        removed_nodes = setdiff(
-            vcat([c.nodes for c in cluster_sets[disturbance_cluster_idx-1]]...),
-            vcat([c.nodes for c in clusters]...)
-        )
-        if !isempty(removed_nodes)
-            @info "Removed nodes due to disturbance event (since previous cluster):\n" *
-                  "\t$(join(removed_nodes, "\n\t"))"
-        end
+        # removed_nodes = setdiff(
+        #     vcat([c.nodes for c in cluster_sets[disturbance_index_count]]...),
+        #     vcat([c.nodes for c in clusters]...)
+        # )
+        # if !isempty(removed_nodes)
+        #     @info "Removed nodes due to disturbance event (since previous cluster):\n" *
+        #           "\t$(join(removed_nodes, "\n\t"))"
+        # end
         # Re-generate the cluster centroids to route mothership
         cluster_centroids_df = generate_cluster_df(clusters, problem.depot)
 

--- a/src/problem/solve_problem.jl
+++ b/src/problem/solve_problem.jl
@@ -2,17 +2,21 @@
 """
     initial_solution(
         problem::Problem;
-        disturbance_clusters::Set{Int64}=Set{Int64}()
+        disturbance_clusters::Set{Int64}=Set{Int64}(),
+        waypoint_optim_flag::Bool=true,
     )::MSTSolution
 
-Generate a solution to the problem for:
-- the mothership by using the nearest neighbour heuristic to generate an initial solution,
-    and then improving using the 2-opt heuristic, and
+Generate an initial solution to the problem for:
+- the mothership by using the nearest neighbour heuristic
+and then improving using the 2-opt heuristic, and
 -  for tenders using the sequential nearest neighbour heuristic.
+Optionally, optimize waypoints using gradient descent.
 
 # Arguments
 - `problem`: Problem instance to solve
+- `k`: Number of clusters to generate
 - `disturbance_clusters`: Set of sequenced clusters to simulate disturbances before.
+- `waypoint_optim_flag`: Flag to indicate whether to optimize the waypoints of the solution.
 
 # Returns
 Best total MSTSolution found
@@ -20,7 +24,8 @@ Best total MSTSolution found
 function initial_solution(
     problem::Problem;
     k::Int=1,
-    disturbance_clusters::Set{Int64}=Set{Int64}()
+    disturbance_clusters::Set{Int64}=Set{Int64}(),
+    waypoint_optim_flag::Bool=true,
 )::MSTSolution
     n_events = length(disturbance_clusters) + 1
     cluster_sets = Vector{Vector{Cluster}}(undef, n_events)
@@ -115,9 +120,13 @@ function initial_solution(
     end
 
     solution_init::MSTSolution = MSTSolution(cluster_sets, ms_soln_sets, tender_soln_sets)
-    solution_opt::MSTSolution = optimize_waypoints(solution_init, problem)
 
-    return solution_opt
+    if waypoint_optim_flag
+        @info "Optimizing waypoints using gradient descent"
+        return optimize_waypoints(solution_init, problem)
+    else
+        return solution_init
+    end
 end
 
 """

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -72,7 +72,7 @@ function get_feasible_vector(
     nodes::Vector{Point{2,Float64}}, exclusions::POLY_VEC
 )::Tuple{Vector{Float64},Vector{Vector{LineString{2,Float64}}}}
     n_points = length(nodes) - 1
-    dist_vector = fill(Inf, n_points)
+    dist_vector = zeros(Float64, n_points)
     path_vector = fill(Vector{LineString{2,Float64}}(), n_points)
 
     for point_i_idx in 1:n_points
@@ -85,9 +85,9 @@ function get_feasible_vector(
                     shortest_feasible_path(
                         point_nodes[1], point_nodes[2], exclusions
                     )
+            else
+                dist_vector[point_i_idx] = Inf
             end
-        else
-            dist_vector[point_i_idx] = 0.0
         end
     end
     @assert !any(isinf.(dist_vector)) "Feasible distances contain infinite values"

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -500,10 +500,8 @@ function build_graph(
         haversine.(points_from, points_to)
     )
 
-    # Only add polygon edges and extra visible connections if:
-    # 1. A polygon is provided, AND
-    # 2. Direct line/path from initial_point -> final_point is NOT visible (i.e. obstructed)
-    if !is_visible(initial_point, final_point, final_polygon)
+    # Only add polygon edges and extra visible connections if final_point is not in network
+    if final_point ∉ points_to
         # Cache to reuse for masking visible vertices
         visibility_mask = falses(length(final_poly_verts))
 

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -86,6 +86,8 @@ function get_feasible_vector(
                         point_nodes[1], point_nodes[2], exclusions
                     )
             end
+        else
+            dist_vector[point_i_idx] = 0.0
         end
     end
 

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -90,7 +90,7 @@ function get_feasible_vector(
             dist_vector[point_i_idx] = 0.0
         end
     end
-
+    @assert !any(isinf.(dist_vector)) "Feasible distances contain infinite values"
     return dist_vector, path_vector
 end
 

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -316,6 +316,8 @@ function shortest_feasible_path(
 
     # Use A* algorithm to find shortest path
     path = a_star(graph, initial_point_idx, final_point_idx, graph.weights)
+    @assert !iszero(length(path)) "No path ($initial_point -> $final_point) because " *
+                                  "network/graph incomplete"
     dist = sum(graph.weights[p.src, p.dst] for p in path)
 
     linestring_path::Vector{LineString} = [

--- a/src/routing/feasible_paths.jl
+++ b/src/routing/feasible_paths.jl
@@ -90,7 +90,8 @@ function get_feasible_vector(
             end
         end
     end
-    @assert !any(isinf.(dist_vector)) "Feasible distances contain infinite values"
+    any(isinf.(dist_vector)) && throw(DomainError(dist_vector[findall(isinf, dist_vector)],
+        "Distance vector contains Inf values, indicating a waypoint in an exclusion zone."))
     return dist_vector, path_vector
 end
 

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -813,7 +813,7 @@ function nearest_neighbour(
     # adjust_waypoints to ensure not within exclusion zones - allows for feasible path calc
     feasible_centroids::Vector{Point{2,Float64}} = adjust_waypoint.(
         Point{2,Float64}.(cluster_centroids.lon, cluster_centroids.lat),
-        Ref(exclusions_mothership.geometry)
+        Ref(exclusions_mothership)
     )
     cluster_centroids[!, :lon] = [pt[1] for pt in feasible_centroids]
     cluster_centroids[!, :lat] = [pt[2] for pt in feasible_centroids]
@@ -821,7 +821,7 @@ function nearest_neighbour(
     # Create distance matrix between start, end, and feasible cluster centroids
     dist_matrix = get_feasible_matrix(
         vcat([current_point], feasible_centroids),
-        exclusions_mothership.geometry
+        exclusions_mothership
     )[1]
     centroid_matrix = dist_matrix[3:end, 3:end]
     current_dist_vector = dist_matrix[1, 3:end]

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -305,6 +305,7 @@ function optimize_waypoints(
     best_soln::MSTSolution = soln
     best_score::Float64 = critical_path(soln, vessel_weightings)
     best_count::Int64 = 0
+    soln_proposed::MSTSolution = soln
 
     # Objective from x -> critical_path
     function obj(

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -271,12 +271,10 @@ Updated mothership and tender solution with optimized waypoint positions and reg
 function optimize_waypoints(
     soln_ex::MSTSolution,
     problem::Problem;
-    opt_method=GradientDescent(
-    # alphaguess=Optim.LineSearches.InitialConstantChange()
-    ),
+    opt_method=SAMIN(ns=1), # Fminbox(GradientDescent()),
     cost_tol::Float64=0.0,
     gradient_tol::Float64=3e4,
-    iterations::Int64=10,
+    iterations::Int64=100,
     time_limit::Float64=60.0
 )::MSTSolution
     soln = deepcopy(soln_ex)
@@ -358,6 +356,7 @@ function optimize_waypoints(
         f_reltol=cost_tol,
         g_abstol=gradient_tol,
         show_trace=true,
+        show_every=10,
         allow_f_increases=false,  # allow or disallow objective function value to increase
         time_limit=time_limit
     )
@@ -371,7 +370,7 @@ function optimize_waypoints(
         lb,
         ub,
         x0,
-        Fminbox(opt_method),
+        opt_method,
         opt_options
     )
 

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -294,6 +294,9 @@ function optimize_waypoints(
     # Initialize variables for objective function
     wpts_length::Int64 = length(waypoints_initial) + 2 # +2 for depot start/end points
     wpts::Vector{Point{2,Float64}} = Vector{Point{2,Float64}}(undef, wpts_length)
+    wpts[1] = last_ms_route.route.nodes[1] # Depot start fixed
+    wpts[end] = last_ms_route.route.nodes[end] # Depot end fixed
+
     has_bad_waypoint::BitVector = falses(wpts_length)
     exclusion_count::Int64 = 0
     score::Float64 = 0.0
@@ -307,11 +310,9 @@ function optimize_waypoints(
         x::Vector{Float64};
     )::Float64
         # Rebuild waypoints
-        wpts .= Point.([
-            last_ms_route.route.nodes[1],  # first waypoint (depot)
-            tuple.(x[1:2:end], x[2:2:end])...,
-            last_ms_route.route.nodes[end]  # last waypoint (depot)
-        ])
+        @inbounds for i in 1:length(waypoints_initial)
+            wpts[i+1] = Point(x[2i-1], x[2i])
+        end
 
         # Exit early here if any waypoints are inside exclusion zones
         has_bad_waypoint = point_in_exclusion.(wpts, Ref(exclusions_mothership))

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -670,7 +670,6 @@ function update_tender_distance_matrix(
     coords_below_diag::Vector{CartesianIndex{2}} = coords_for_value.(
         Ref(dist_matrix), old_sortie_matrix_dists
     )
-    @assert all(length.(coord_pairs) .== 2) "Each distance should appear exactly twice in symmetric matrix"
 
     swap_ij(I::CartesianIndex{2}) = CartesianIndex(I[2], I[1])
     coords_above_diag::Vector{CartesianIndex{2}} = swap_ij.(coords_below_diag)

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -363,8 +363,8 @@ function optimize_waypoints(
     )
 
     # Each waypoint is bounded to its surrounding area (in decimal degrees)
-    lb = x0 .- 0.05
-    ub = x0 .+ 0.05
+    lb = x0 .- 0.025
+    ub = x0 .+ 0.025
 
     result = optimize(
         obj,

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -269,7 +269,7 @@ zones.
 Updated mothership and tender solution with optimized waypoint positions and regenerated tender sorties
 """
 function optimize_waypoints(
-    soln_ex::MSTSolution,
+    soln::MSTSolution,
     problem::Problem;
     opt_method=SAMIN(ns=1), # Fminbox(GradientDescent()),
     cost_tol::Float64=0.0,
@@ -277,7 +277,6 @@ function optimize_waypoints(
     iterations::Int64=100,
     time_limit::Float64=60.0
 )::MSTSolution
-    soln = deepcopy(soln_ex)
     exclusions_mothership::POLY_VEC = problem.mothership.exclusion.geometry
     exclusions_tender::POLY_VEC = problem.tenders.exclusion.geometry
     vessel_weightings::NTuple{2,AbstractFloat} = (

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -334,7 +334,7 @@ function optimize_waypoints(
         @assert !isinf(score) "Critical path cost is infinite, indicating a bad waypoint!"
 
         if score < best_score[]
-            best_soln[] = soln_proposed
+            best_soln[] = deepcopy(soln_proposed)
             best_score[] = score
             best_count[] = 0
         else

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -1088,7 +1088,9 @@ function two_opt(
         if length(sortie.nodes) ≤ 1
             # If there is only 1 node between start and finish, no change is possible
             # update to distance vector
-            dist_vector = get_superdiag_vals(sortie.dist_matrix)
+            dist_vector = typeof(sortie.dist_matrix) == Matrix{Float64} ?
+                          get_superdiag_vals(sortie.dist_matrix) :
+                          sortie.dist_matrix
             sorties_new[idx] = Route(
                 sortie.nodes,
                 dist_vector,

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -269,7 +269,7 @@ zones.
 Updated mothership and tender solution with optimized waypoint positions and regenerated tender sorties
 """
 function optimize_waypoints(
-    soln::MSTSolution,
+    soln_ex::MSTSolution,
     problem::Problem;
     opt_method=GradientDescent(
     # alphaguess=Optim.LineSearches.InitialConstantChange()
@@ -279,6 +279,7 @@ function optimize_waypoints(
     iterations::Int64=10,
     time_limit::Float64=60.0
 )::MSTSolution
+    soln = deepcopy(soln_ex)
     exclusions_mothership::POLY_VEC = problem.mothership.exclusion.geometry
     exclusions_tender::POLY_VEC = problem.tenders.exclusion.geometry
     vessel_weightings::NTuple{2,AbstractFloat} = (

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -670,6 +670,7 @@ function update_tender_distance_matrix(
     coords_below_diag::Vector{CartesianIndex{2}} = coords_for_value.(
         Ref(dist_matrix), old_sortie_matrix_dists
     )
+    @assert all(length.(coord_pairs) .== 2) "Each distance should appear exactly twice in symmetric matrix"
 
     swap_ij(I::CartesianIndex{2}) = CartesianIndex(I[2], I[1])
     coords_above_diag::Vector{CartesianIndex{2}} = swap_ij.(coords_below_diag)

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -302,9 +302,9 @@ function optimize_waypoints(
     exclusion_count::Int64 = 0
     score::Float64 = 0.0
 
-    best_soln = Ref{MSTSolution}(soln)
-    best_score = Ref(Inf)
-    best_count = Ref(0)
+    best_soln::MSTSolution = soln
+    best_score::Float64 = critical_path(soln, vessel_weightings)
+    best_count::Int64 = 0
 
     # Objective from x -> critical_path
     function obj(
@@ -324,7 +324,7 @@ function optimize_waypoints(
         end
 
         soln_proposed = rebuild_solution_with_waypoints(
-            best_soln[],
+            soln,
             wpts,
             exclusions_mothership,
             exclusions_tender
@@ -333,19 +333,19 @@ function optimize_waypoints(
         score = critical_path(soln_proposed, vessel_weightings)
         @assert !isinf(score) "Critical path cost is infinite, indicating a bad waypoint!"
 
-        if score < best_score[]
-            best_soln[] = deepcopy(soln_proposed)
-            best_score[] = score
-            best_count[] = 0
+        if score < best_score
+            best_soln = deepcopy(soln_proposed)
+            best_score = score
+            best_count = 0
         else
             # For debugging and tracking
-            best_count[] += 1
+            best_count += 1
         end
 
         if !isnothing(Plot.current_axis())
             Plot.empty!(Plot.current_axis())
         end
-        display(Plot.debug_waypoints(problem, wpts; title="Score: $(score) | Iter: $(best_count[])"))
+        display(Plot.debug_waypoints(problem, wpts; title="Score: $(score) | Iter: $(best_count)"))
         # display(Plot.solution(problem, soln_proposed))
 
         return score
@@ -382,7 +382,7 @@ function optimize_waypoints(
     @info "Gradient status:" Optim.g_converged(result)
     # @info "Gradient trace:" Optim.g_norm_trace(result)
 
-    return best_soln[]
+    return best_soln
 end
 
 """

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -317,17 +317,8 @@ function optimize_waypoints(
         has_bad_waypoint = point_in_exclusion.(wpts, Ref(exclusions_mothership))
         exclusion_count = count(has_bad_waypoint)
         if exclusion_count > 0
-            soln_proposed = rebuild_solution_with_waypoints(
-                best_soln[],
-                wpts,
-                exclusions_mothership,
-                exclusions_tender
-            )
-
-            naive_score = critical_path(soln_proposed, vessel_weightings)
+            naive_score = sum(haversine.(wpts[1:end-1], wpts[2:end])) * vessel_weightings[1]
             return naive_score * (exclusion_count + 1)^2
-            # naive_score = sum(haversine.(wpts[1:end-1], wpts[2:end])) * vessel_weightings[1]
-            # return naive_score + naive_score * (exclusion_count + 1)^2
         end
 
         soln_proposed = rebuild_solution_with_waypoints(

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -667,17 +667,19 @@ function update_tender_distance_matrix(
     new_sortie_matrix_dists::Vector{Float64} = vcat(getfield.(sorties_new, :dist_matrix)...)
 
     #! Not a bulletproof way to find/update, as distance value may not be unique
-    coord_pairs = findall.(.==(old_sortie_matrix_dists), Ref(dist_matrix))
+    coord_pairs::Vector{Vector{CartesianIndex{2}}} = findall.(
+        .==(old_sortie_matrix_dists), Ref(dist_matrix)
+    )
     !all(length.(coord_pairs) .== 2) && throw(DimensionMismatch(
         "Expected 2 coordinates per old sortie distance"
     ))
 
-    coords_below_diag = getindex.(coord_pairs, 1)
-    coords_above_diag = getindex.(coord_pairs, 2)
+    coords_below_diag::Vector{CartesianIndex{2}} = getindex.(coord_pairs, 1)
+    coords_above_diag::Vector{CartesianIndex{2}} = getindex.(coord_pairs, 2)
     !all(getfield.(coords_below_diag, :I) .== reverse.(getfield.(coords_above_diag, :I))) &&
         throw(ErrorException("Expected symmetric coordinates for old sortie distances"))
 
-    dist_matrix_new = copy(dist_matrix)
+    dist_matrix_new::Matrix{Float64} = copy(dist_matrix)
     dist_matrix_new[coords_below_diag] .= new_sortie_matrix_dists
     dist_matrix_new[coords_above_diag] .= new_sortie_matrix_dists
 

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -332,7 +332,7 @@ function optimize_waypoints(
         @assert !isinf(score) "Critical path cost is infinite, indicating a bad waypoint!"
 
         if score < best_score
-            best_soln = deepcopy(soln_proposed)
+            best_soln = soln_proposed
             best_score = score
             best_count = 0
         else
@@ -413,7 +413,7 @@ function rebuild_solution_with_waypoints(
         waypoints_proposed, exclusions_mothership
     )
     ms_route_new::Route = Route(
-        waypoints_proposed,
+        copy(waypoints_proposed),
         dist_vector_proposed,
         vcat(line_strings_proposed...)
     )

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -474,7 +474,7 @@ function rebuild_sortie(
 )::Route
     segment_to_keep = route.line_strings
     updated_dist_matrix = typeof(route.dist_matrix) == Vector{Float64} ?
-                          route.dist_matrix :
+                          copy(route.dist_matrix) :
                           get_superdiag_vals(route.dist_matrix)
 
     # Keep the segments of the line strings that contain matching start/end points

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -329,7 +329,7 @@ function optimize_waypoints(
         )
 
         score = critical_path(soln_proposed, vessel_weightings)
-        # Main.@infiltrate isinf(score)
+        @assert !isinf(score) "Critical path cost is infinite, indicating a bad waypoint!"
 
         if score < best_score[]
             best_soln[] = soln_proposed

--- a/src/routing/routing_heuristics.jl
+++ b/src/routing/routing_heuristics.jl
@@ -239,11 +239,11 @@ end
 """
     optimize_waypoints(
         soln::MSTSolution,
-        problem::Problem;
-        opt_method=GradientDescent(),
+        problem::Problem,
+        opt_method;
         cost_tol::Float64=0.0,
-        gradient_tol::Float64=3e5,
-        iterations::Int64=10,
+        gradient_tol::Float64=3e4,
+        iterations::Int64=100,
         time_limit::Float64=60.0
     )::MSTSolution
 
@@ -258,20 +258,22 @@ zones.
 # Arguments
 - `soln::MSTSolution`: Current mothership and tender solution.
 - `problem::Problem`: Definition of problem context (vessel specs and exclusion zones)
-- `opt_method`: Optimization algorithm (default: GradientDescent())
-- `cost_tol`: Relative cost function tolerance. Stop optimization if function falls below this value.
-- `gradient_tol::Float64`: Gradient norm convergence tolerance. \
-                           Stop optimization when gradient norm falls below this value
+- `opt_method`: Optimization algorithm used to improve waypoint positions.
+- `cost_tol`: Relative cost function tolerance. Stop optimization if function falls below
+this value.
+- `gradient_tol::Float64`: Gradient norm convergence tolerance. Stop optimization when
+gradient norm falls below this value
 - `iterations::Int64`: Maximum number of optimization iterations
 - `time_limit::Float64`: Soft limit on the time spent optimizing
 
 # Returns
-Updated mothership and tender solution with optimized waypoint positions and regenerated tender sorties
+Updated mothership and tender solution with optimized waypoint positions and regenerated
+tender sorties
 """
 function optimize_waypoints(
     soln::MSTSolution,
-    problem::Problem;
-    opt_method=SAMIN(ns=1), # Fminbox(GradientDescent()),
+    problem::Problem,
+    opt_method;
     cost_tol::Float64=0.0,
     gradient_tol::Float64=3e4,
     iterations::Int64=100,


### PR DESCRIPTION
Review after #115  merged

Metrics
- Adds `tender_sortie_dist()` method to calculate tender sortie distance directly using a distance vector, for compatability.
- Introduces an assertion in `critical_path()` to validate sortie distances, enhancing the reliability of calculations.

Vessel weightings
- Introduces vessel weighting alias.
- Carries vessel weightings through to `critical_path()` calls.
- Removes the default vessel weighting argument in critical path calculations and solution improvement.

Typing
- Corrects use exclusion geometries as `POLY_VEC` for compatibility.
- Updates code to ensure type compatibility for sortie distance matrices and clarifies variable types.
- Adds type annotations for clarity.
_
- Removes logging of removed nodes after a disturbance event, due to current errors. (Addressed and re-introduced in future PR)